### PR TITLE
✨ Add slash command support (Fixes #2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "illuminate/http": "^10.0",
     "laravel-zero/framework": "^10.2",
     "nunomaduro/termwind": "^1.15.1",
+    "react/async": "^4.2",
     "team-reflex/discord-php": "^7.3"
   },
   "require-dev": {

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -2,126 +2,41 @@
 
 namespace Laracord\Commands;
 
-use Illuminate\Support\Str;
 use Laracord\Commands\Components\Message;
 use Laracord\Commands\Contracts\Command as CommandContract;
-use Laracord\Laracord;
 
-abstract class Command implements CommandContract
+abstract class Command extends AbstractCommand implements CommandContract
 {
     /**
-     * The bot instance.
-     *
-     * @var \Laracord\Laracord
-     */
-    protected $bot;
-
-    /**
-     * The console instance.
-     *
-     * @var \Laracord\Console\Commands\Command
-     */
-    protected $console;
-
-    /**
-     * The Discord instance.
-     *
-     * @var \Discord\DiscordCommandClient
-     */
-    protected $discord;
-
-    /**
-     * The user instance.
-     *
-     * @var \App\Models\User
-     */
-    protected $user;
-
-    /**
-     * The server instance.
-     *
-     * @var \Discord\Parts\Guild\Guild
-     */
-    protected $server;
-
-    /**
-     * The Discord command name.
-     *
-     * @var string
-     */
-    protected $name;
-
-    /**
-     * The Discord command aliases.
+     * The command aliases.
      *
      * @var array
      */
     protected $aliases = [];
 
     /**
-     * The Discord command description.
-     *
-     * @var string|null
-     */
-    protected $description;
-
-    /**
-     * The Discord command cooldown.
+     * The command cooldown.
      *
      * @var int
      */
     protected $cooldown = 0;
 
     /**
-     * The Discord command cooldown message.
+     * The command cooldown message.
      *
      * @var string
      */
     protected $cooldownMessage = '';
 
     /**
-     * The Discord command usage.
+     * The command usage.
      *
      * @var string
      */
     protected $usage = '';
 
     /**
-     * Indiciates whether the command requires admin permissions.
-     *
-     * @var bool
-     */
-    protected $admin = false;
-
-    /**
-     * Indicates whether the command should be displayed in the commands list.
-     *
-     * @var bool
-     */
-    protected $hidden = false;
-
-    /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct(Laracord $bot)
-    {
-        $this->bot = $bot;
-        $this->console = $bot->console();
-        $this->discord = $bot->discord();
-    }
-
-    /**
-     * Make a new command instance.
-     */
-    public static function make(Laracord $bot): self
-    {
-        return new static($bot);
-    }
-
-    /**
-     * Maybe handle the Discord command.
+     * Maybe handle the command.
      *
      * @param  \Discord\Parts\Channel\Message  $message
      * @param  array  $args
@@ -129,6 +44,12 @@ abstract class Command implements CommandContract
      */
     public function maybeHandle($message, $args)
     {
+        if (! $this->isAdminCommand()) {
+            $this->handle($message, $args);
+
+            return;
+        }
+
         $this->user = $this->getUser($message->author);
         $this->server = $message->channel->guild;
 
@@ -140,133 +61,13 @@ abstract class Command implements CommandContract
     }
 
     /**
-     * Handle the Discord command.
+     * Handle the command.
      *
      * @param  \Discord\Parts\Channel\Message  $message
      * @param  array  $args
      * @return void
      */
     abstract public function handle($message, $args);
-
-    /**
-     * Build an embed for use in a Discord message.
-     *
-     * @param  string  $content
-     * @return \Laracord\Commands\Components\Message
-     */
-    public function message($content = '')
-    {
-        return Message::make($this->bot())
-            ->content($content);
-    }
-
-    /**
-     * Send a log to console.
-     *
-     * @param  string  $message
-     * @return void
-     */
-    public function log($message)
-    {
-        return $this->console->info($message);
-    }
-
-    /**
-     * Get the command user.
-     *
-     * @param  \Discord\Parts\User\User|null  $user
-     * @return \App\Models\User
-     */
-    public function getUser($user = null)
-    {
-        $model = Str::start(app()->getNamespace(), '\\').'Models\\User';
-
-        return $user ? $model::firstOrCreate(['discord_id' => $user->id], [
-            'discord_id' => $user->id,
-            'username' => $user->username,
-        ]) : $this->user;
-    }
-
-    /**
-     * Get the command server.
-     *
-     * @return \Discord\Parts\Guild\Guild
-     */
-    public function getServer()
-    {
-        return $this->server;
-    }
-
-    /**
-     * Resolve a Discord user.
-     *
-     * @param  string  $username
-     * @return \Discord\Parts\User\User|null
-     */
-    public function resolveUser($username = null)
-    {
-        return ! empty($username) ? $this->getServer()->members->filter(function ($member) use ($username) {
-            $username = str_replace(['<', '@', '>'], '', strtolower($username));
-
-            return ($member->user->username === $username || $member->user->id === $username) && ! $member->user->bot;
-        })->first() : null;
-    }
-
-    /**
-     * Retrieve the command name.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
-     * Retrieve the command signature.
-     *
-     * @return string
-     */
-    public function getSignature()
-    {
-        return Str::start($this->getName(), $this->bot()->getPrefix());
-    }
-
-    /**
-     * Retrieve the full command syntax.
-     *
-     * @return string
-     */
-    public function getSyntax()
-    {
-        $command = $this->getSignature();
-
-        if (! empty($this->usage)) {
-            $command .= " `{$this->usage}`";
-        }
-
-        return $command;
-    }
-
-    /**
-     * Retrieve the command aliases.
-     *
-     * @return array
-     */
-    public function getAliases()
-    {
-        return $this->aliases;
-    }
-
-    /**
-     * Retrieve the command description.
-     *
-     * @return string
-     */
-    public function getDescription()
-    {
-        return $this->description;
-    }
 
     /**
      * Retrieve the command cooldown.
@@ -299,52 +100,12 @@ abstract class Command implements CommandContract
     }
 
     /**
-     * Retrieve the bot instance.
+     * Retrieve the command aliases.
      *
-     * @return \Laracord\Laracord
+     * @return array
      */
-    public function bot()
+    public function getAliases()
     {
-        return $this->bot;
-    }
-
-    /**
-     * Retrieve the console instance.
-     *
-     * @return \Laracord\Console\Commands\Command
-     */
-    public function console()
-    {
-        return $this->console;
-    }
-
-    /**
-     * Retrieve the Discord instance.
-     *
-     * @return \Discord\DiscordCommandClient
-     */
-    public function discord()
-    {
-        return $this->discord;
-    }
-
-    /**
-     * Determine if the command requires admin permissions.
-     *
-     * @return bool
-     */
-    public function isAdminCommand()
-    {
-        return $this->admin;
-    }
-
-    /**
-     * Determine if the command is hidden.
-     *
-     * @return bool
-     */
-    public function isHidden()
-    {
-        return $this->hidden;
+        return $this->aliases;
     }
 }

--- a/src/Commands/Components/Message.php
+++ b/src/Commands/Components/Message.php
@@ -7,6 +7,7 @@ use Discord\Builders\Components\Button;
 use Discord\Builders\MessageBuilder;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message as ChannelMessage;
+use Discord\Parts\User\User;
 use Exception;
 use Laracord\Laracord;
 
@@ -177,6 +178,34 @@ class Message
         }
 
         $this->getChannel()->sendMessage($this->build());
+    }
+
+    /**
+     * Send the message to a user.
+     */
+    public function sendTo(mixed $user): void
+    {
+        if (is_numeric($user)) {
+            $member = app('bot')->discord()->users->get('id', $user);
+
+            if (! $member) {
+                app('bot')->console()->error("Could not find user <fg=red>{$user}</> to send message");
+
+                return;
+            }
+
+            $user = $member;
+        }
+
+        if ($user instanceof ChannelMessage) {
+            $user = $user->author;
+        }
+
+        if (! $user instanceof User) {
+            throw new Exception('You must provide a valid Discord user.');
+        }
+
+        $user->sendMessage($this->build());
     }
 
     /**

--- a/src/Commands/Contracts/Command.php
+++ b/src/Commands/Contracts/Command.php
@@ -7,7 +7,7 @@ use Discord\Parts\Channel\Message;
 interface Command
 {
     /**
-     * Execute the Discord command.
+     * Handle the command.
      */
     public function handle(Message $message, array $args);
 }

--- a/src/Commands/Contracts/SlashCommand.php
+++ b/src/Commands/Contracts/SlashCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laracord\Commands\Contracts;
+
+use Discord\Parts\Interactions\Interaction;
+
+interface SlashCommand
+{
+    /**
+     * Handle the slash command.
+     */
+    public function handle(Interaction $interaction);
+}

--- a/src/Commands/HelpCommand.php
+++ b/src/Commands/HelpCommand.php
@@ -5,14 +5,14 @@ namespace Laracord\Commands;
 class HelpCommand extends Command
 {
     /**
-     * The Discord command name.
+     * The command name.
      *
      * @var string
      */
     protected $name = 'help';
 
     /**
-     * The Discord command description.
+     * The command description.
      *
      * @var string|null
      */
@@ -40,7 +40,7 @@ class HelpCommand extends Command
     protected $message = 'Here is a list of all available commands.';
 
     /**
-     * Execute the Discord command.
+     * Handle the command.
      *
      * @param  \Discord\Parts\Channel\Message  $message
      * @param  array  $args

--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Laracord\Commands;
+
+use Discord\Builders\CommandBuilder;
+use Discord\Parts\Interactions\Command\Command as DiscordCommand;
+use Discord\Parts\Interactions\Command\Option as DiscordOption;
+use Illuminate\Support\Str;
+use Laracord\Commands\Contracts\SlashCommand as SlashCommandContract;
+
+abstract class SlashCommand extends AbstractCommand implements SlashCommandContract
+{
+    /**
+     * The guild the command belongs to.
+     *
+     * @var string
+     */
+    protected $guild;
+
+    /**
+     * The command options.
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * The registered command options.
+     *
+     * @var array
+     */
+    protected $registeredOptions = [];
+
+    /**
+     * Create a Discord command instance.
+     */
+    public function create(): DiscordCommand
+    {
+        $command = CommandBuilder::new()
+            ->setName($this->getName())
+            ->setDescription($this->getDescription());
+
+        if ($this->getOptions()) {
+            foreach ($this->getOptions() as $option) {
+                $command = $command->addOption($option);
+            }
+        }
+
+        $command = collect($command->toArray())
+            ->put('guild_id', $this->getGuild())
+            ->filter()
+            ->all();
+
+        return new DiscordCommand($this->discord(), $command);
+    }
+
+    /**
+     * Handle the slash command.
+     *
+     * @param  \Discord\Parts\Interactions\Interaction  $interaction
+     * @return void
+     */
+    abstract public function handle($interaction);
+
+    /**
+     * Maybe handle the slash command.
+     *
+     * @param  \Discord\Parts\Interactions\Interaction  $interaction
+     * @return void
+     */
+    public function maybeHandle($interaction)
+    {
+        if (! $this->isAdminCommand()) {
+            $this->handle($interaction);
+
+            return;
+        }
+
+        $this->user = $this->getUser($interaction->member->user);
+        $this->server = $interaction->guild;
+
+        if ($this->isAdminCommand() && ! $this->user->is_admin) {
+            return;
+        }
+
+        $this->handle($interaction);
+    }
+
+    /**
+     * Set the command options.
+     *
+     * @return array
+     */
+    public function options()
+    {
+        return [];
+    }
+
+    /**
+     * Retrieve the command signature.
+     *
+     * @return string
+     */
+    public function getSignature()
+    {
+        return Str::start($this->getName(), '/');
+    }
+
+    /**
+     * Retrieve the slash command guild.
+     *
+     * @return string
+     */
+    public function getGuild()
+    {
+        return $this->guild;
+    }
+
+    /**
+     * Retrieve the slash command options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        if ($this->registeredOptions) {
+            return $this->registeredOptions;
+        }
+
+        $options = collect($this->options())->merge($this->options);
+
+        if ($options->isEmpty()) {
+            return $this->registeredOptions = null;
+        }
+
+        return $this->registeredOptions = $options->map(fn ($option) => $option instanceof DiscordOption
+            ? $option
+            : new DiscordOption($this->discord(), $option)
+        )->map(fn ($option) => $option->setName(Str::slug($option->name)))->all();
+    }
+}

--- a/src/Console/Commands/MakeSlashCommand.php
+++ b/src/Console/Commands/MakeSlashCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Laracord\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class MakeSlashCommand extends GeneratorCommand
+{
+    /**
+     * The command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:slash-command';
+
+    /**
+     * The command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Discord slash command';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Discord slash command';
+
+    /**
+     * Replace the class name for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return string
+     */
+    protected function replaceClass($stub, $name)
+    {
+        $stub = parent::replaceClass($stub, $name);
+
+        $command = $this->option('command') ?: Str::of($name)->classBasename()->kebab()->value();
+
+        return str_replace(['dummy:command', '{{ command }}'], $command, $stub);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        $relativePath = '/stubs/slash-command.stub';
+
+        return file_exists($customPath = $this->laravel->basePath(trim($relativePath, '/')))
+            ? $customPath
+            : __DIR__.$relativePath;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\SlashCommands';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the slash command'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the Discord slash command already exists'],
+            ['command', null, InputOption::VALUE_OPTIONAL, 'The Discord slash command that will be used to invoke the class'],
+        ];
+    }
+}

--- a/src/Console/Commands/ModelMakeCommand.php
+++ b/src/Console/Commands/ModelMakeCommand.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Laracord\Console\Commands;
+
+use Illuminate\Foundation\Console\ModelMakeCommand as FoundationModelMakeCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function Laravel\Prompts\multiselect;
+
+class ModelMakeCommand extends FoundationModelMakeCommand
+{
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if ($this->handleMake() === false && ! $this->option('force')) {
+            return false;
+        }
+
+        if ($this->option('all')) {
+            $this->input->setOption('factory', true);
+            $this->input->setOption('seed', true);
+            $this->input->setOption('migration', true);
+        }
+
+        if ($this->option('factory')) {
+            $this->createFactory();
+        }
+
+        if ($this->option('migration')) {
+            $this->createMigration();
+        }
+
+        if ($this->option('seed')) {
+            $this->createSeeder();
+        }
+    }
+
+    /**
+     * Handle the make command.
+     *
+     * @return void
+     */
+    protected function handleMake()
+    {
+        if ($this->isReservedName($this->getNameInput())) {
+            $this->components->error('The name "'.$this->getNameInput().'" is reserved by PHP.');
+
+            return false;
+        }
+
+        $name = $this->qualifyClass($this->getNameInput());
+
+        $path = $this->getPath($name);
+
+        if (
+            (! $this->hasOption('force') || ! $this->option('force'))
+            && $this->alreadyExists($this->getNameInput())
+        ) {
+            $this->components->error($this->type.' already exists.');
+
+            return false;
+        }
+
+        $this->makeDirectory($path);
+
+        $this->files->put($path, $this->sortImports($this->buildClass($name)));
+
+        $info = $this->type;
+
+        if (windows_os()) {
+            $path = str_replace('/', '\\', $path);
+        }
+
+        $this->components->info(sprintf('%s [%s] created successfully.', $info, $path));
+    }
+
+    /**
+     * Create a migration file for the model.
+     *
+     * @return void
+     */
+    protected function createMigration()
+    {
+        $table = Str::snake(Str::pluralStudly(class_basename($this->argument('name'))));
+
+        $this->call('make:migration', [
+            'name' => "create_{$table}_table",
+            '--create' => $table,
+            '--fullpath' => true,
+        ]);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/model.stub');
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['all', 'a', InputOption::VALUE_NONE, 'Generate migration, factory, and seed classes for the model'],
+            ['factory', 'f', InputOption::VALUE_NONE, 'Create a new factory for the model'],
+            ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists'],
+            ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model'],
+            ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
+        ];
+    }
+
+    /**
+     * Interact further with the user if they were prompted for missing arguments.
+     *
+     * @return void
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
+            return;
+        }
+
+        collect(multiselect('Would you like any of the following?', [
+            'seed' => 'Database Seeder',
+            'factory' => 'Factory',
+            'migration' => 'Migration',
+        ]))->each(fn ($option) => $input->setOption($option, true));
+    }
+}

--- a/src/Console/Commands/stubs/command.stub
+++ b/src/Console/Commands/stubs/command.stub
@@ -7,14 +7,14 @@ use Laracord\Commands\Command;
 class {{ class }} extends Command
 {
     /**
-     * The Discord command name.
+     * The command name.
      *
      * @var string
      */
     protected $name = '{{ command }}';
 
     /**
-     * The Discord command description.
+     * The command description.
      *
      * @var string
      */
@@ -35,7 +35,7 @@ class {{ class }} extends Command
     protected $hidden = false;
 
     /**
-     * Execute the Discord command.
+     * Handle the command.
      *
      * @param  \Discord\Parts\Channel\Message  $message
      * @param  array  $args

--- a/src/Console/Commands/stubs/model.stub
+++ b/src/Console/Commands/stubs/model.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class {{ class }} extends Model
+{
+    use HasFactory;
+}

--- a/src/Console/Commands/stubs/slash-command.stub
+++ b/src/Console/Commands/stubs/slash-command.stub
@@ -1,0 +1,60 @@
+<?php
+
+namespace {{ namespace }};
+
+use Laracord\Commands\SlashCommand;
+
+class {{ class }} extends SlashCommand
+{
+    /**
+     * The slash command name.
+     *
+     * @var string
+     */
+    protected $name = '{{ command }}';
+
+    /**
+     * The slash command description.
+     *
+     * @var string
+     */
+    protected $description = 'The {{ command }} slash command.';
+
+    /**
+     * The command options.
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * Indiciates whether the slash command requires admin permissions.
+     *
+     * @var bool
+     */
+    protected $admin = false;
+
+    /**
+     * Indicates whether the slash command should be displayed in the commands list.
+     *
+     * @var bool
+     */
+    protected $hidden = false;
+
+    /**
+     * Handle the slash command.
+     *
+     * @param  \Discord\Parts\Interactions\Interaction  $interaction
+     * @return void
+     */
+    public function handle($interaction)
+    {
+        $interaction->respondWithMessage(
+            $this
+              ->message()
+              ->title('{{ class }}')
+              ->content('Hello world!')
+              ->build()
+        );
+    }
+}

--- a/src/Console/Concerns/WithLog.php
+++ b/src/Console/Concerns/WithLog.php
@@ -8,10 +8,8 @@ trait WithLog
 {
     /**
      * Send a message to the console.
-     *
-     * @return void
      */
-    public function log(string $message, string $type = 'info')
+    public function log(string $message, string $type = 'info'): void
     {
         $message = trim($message);
 
@@ -35,5 +33,29 @@ trait WithLog
         ];
 
         with(new Log($this->getOutput()))->render($config, $message);
+    }
+
+    /**
+     * Send a warning log to console.
+     *
+     * @param  string  $string
+     * @param  string|null  $verbosity
+     * @return void
+     */
+    public function warn($string, $verbosity = null)
+    {
+        return $this->log($string, 'warn');
+    }
+
+    /**
+     * Send an error log to console.
+     *
+     * @param  string  $string
+     * @param  string|null  $verbosity
+     * @return void
+     */
+    public function error($string, $verbosity = null)
+    {
+        return $this->log($string, 'error');
     }
 }

--- a/src/Laracord.php
+++ b/src/Laracord.php
@@ -636,6 +636,12 @@ class Laracord
             return $this->prefix;
         }
 
-        return $this->prefix = config('discord.prefix');
+        $prefix = trim(config('discord.prefix'));
+
+        if (! $prefix || $prefix === '/') {
+            throw new Exception('You must provide a valid command prefix.');
+        }
+
+        return $this->prefix = $prefix;
     }
 }

--- a/src/LaracordServiceProvider.php
+++ b/src/LaracordServiceProvider.php
@@ -31,6 +31,8 @@ class LaracordServiceProvider extends ServiceProvider
             Console\Commands\BootCommand::class,
             Console\Commands\ConsoleMakeCommand::class,
             Console\Commands\MakeCommand::class,
+            Console\Commands\MakeSlashCommand::class,
+            Console\Commands\ModelMakeCommand::class,
             Console\Commands\ServiceMakeCommand::class,
         ]);
     }


### PR DESCRIPTION
## Change log

- ➕ Add `react/async` to the project
- ✨ Implement a simplified `make:model` command (Fixes #9)
- 🎨 Simplify the Command docblocks
- 🎨 Split the Command class into an AbstractCommand class
- 🧑‍💻 Add warn and error override helpers to the `WithLog` trait
- ✨ Add slash command support (Fixes #2)
- ✨ Add user messaging support to the message component (Fixes #10)
- 🎨 Validate the command prefix