### PR TITLE
✨ Implement an optional `react/http` server (Fixes #21)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "guzzlehttp/guzzle": "^7.5",
     "illuminate/database": "^10.0",
     "illuminate/http": "^10.0",
+    "illuminate/translation": "^10.0",
     "laravel-zero/framework": "^10.2",
     "nunomaduro/termwind": "^1.15.1",
     "nyholm/psr7": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "illuminate/http": "^10.0",
     "illuminate/translation": "^10.0",
     "laravel-zero/framework": "^10.2",
+    "laravel/sanctum": "^3.3",
     "nunomaduro/termwind": "^1.15.1",
     "nyholm/psr7": "^1.8",
     "react/async": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,10 @@
     "illuminate/http": "^10.0",
     "laravel-zero/framework": "^10.2",
     "nunomaduro/termwind": "^1.15.1",
+    "nyholm/psr7": "^1.8",
     "react/async": "^4.2",
+    "react/http": "^1.9",
+    "symfony/psr-http-message-bridge": "^6.4",
     "team-reflex/discord-php": "^7.3"
   },
   "require-dev": {

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,44 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Locale Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The application locale determines the default locale that will be used
+    | by the translation service provider. You are free to set this value
+    | to any of the locales which will be supported by the application.
+    |
+    */
+
+    'locale' => 'en',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Fallback Locale
+    |--------------------------------------------------------------------------
+    |
+    | The fallback locale determines the locale to use when the current one
+    | is not available. You may change the value to correspond to any of
+    | the language folders that are provided through your application.
+    |
+    */
+
+    'fallback_locale' => 'en',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Debug Mode
+    |--------------------------------------------------------------------------
+    |
+    | When your application is in debug mode, detailed error messages with
+    | stack traces will be shown on every error that occurs within your
+    | application. If disabled, a simple generic error page is shown.
+    |
+    */
+
+    'debug' => env('APP_ENV', 'production') !== 'production',
+
+];

--- a/config/discord.php
+++ b/config/discord.php
@@ -77,6 +77,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | HTTP Server
+    |--------------------------------------------------------------------------
+    |
+    | The Laracord HTTP server allows you to receive and respond to HTTP
+    | requests from the bot at the specified address/port. This can be useful
+    | for creating a RESTful API for your bot.
+    |
+    | The HTTP server is automatically started when a `routes.php` file is
+    | present and contains valid routes. You can override this behavior by
+    | setting this option to `false`.
+    |
+    */
+
+    'http' => env('HTTP_SERVER', ':8080'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Timestamp Format
     |--------------------------------------------------------------------------
     |

--- a/src/Console/Commands/ControllerMakeCommand.php
+++ b/src/Console/Commands/ControllerMakeCommand.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Laracord\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use InvalidArgumentException;
+use Symfony\Component\Console\Input\InputOption;
+
+use function Laravel\Prompts\confirm;
+
+class ControllerMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:controller';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new controller class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Controller';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/controller.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Http';
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * Remove the base controller import if we are already in the base namespace.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        return parent::buildClass($name);
+    }
+
+    /**
+     * Build the model replacement values.
+     *
+     * @return array
+     */
+    protected function buildModelReplacements(array $replace)
+    {
+        $modelClass = $this->parseModel($this->option('model'));
+
+        if (! class_exists($modelClass) && confirm("A {$modelClass} model does not exist. Do you want to generate it?", default: true)) {
+            $this->call('make:model', ['name' => $modelClass]);
+        }
+
+        $replace = $this->buildFormRequestReplacements($replace, $modelClass);
+
+        return array_merge($replace, [
+            'DummyFullModelClass' => $modelClass,
+            '{{ namespacedModel }}' => $modelClass,
+            '{{namespacedModel}}' => $modelClass,
+            'DummyModelClass' => class_basename($modelClass),
+            '{{ model }}' => class_basename($modelClass),
+            '{{model}}' => class_basename($modelClass),
+            'DummyModelVariable' => lcfirst(class_basename($modelClass)),
+            '{{ modelVariable }}' => lcfirst(class_basename($modelClass)),
+            '{{modelVariable}}' => lcfirst(class_basename($modelClass)),
+        ]);
+    }
+
+    /**
+     * Get the fully-qualified model class name.
+     *
+     * @param  string  $model
+     * @return string
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function parseModel($model)
+    {
+        if (preg_match('([^A-Za-z0-9_/\\\\])', $model)) {
+            throw new InvalidArgumentException('Model name contains invalid characters.');
+        }
+
+        return $this->qualifyModel($model);
+    }
+
+    /**
+     * Build the model replacement values.
+     *
+     * @param  string  $modelClass
+     * @return array
+     */
+    protected function buildFormRequestReplacements(array $replace, $modelClass)
+    {
+        [$namespace, $storeRequestClass, $updateRequestClass] = [
+            'Illuminate\\Http', 'Request', 'Request',
+        ];
+
+        $namespacedRequests = $namespace.'\\'.$storeRequestClass.';';
+
+        if ($storeRequestClass !== $updateRequestClass) {
+            $namespacedRequests .= PHP_EOL.'use '.$namespace.'\\'.$updateRequestClass.';';
+        }
+
+        return array_merge($replace, [
+            '{{ storeRequest }}' => $storeRequestClass,
+            '{{storeRequest}}' => $storeRequestClass,
+            '{{ updateRequest }}' => $updateRequestClass,
+            '{{updateRequest}}' => $updateRequestClass,
+            '{{ namespacedStoreRequest }}' => $namespace.'\\'.$storeRequestClass,
+            '{{namespacedStoreRequest}}' => $namespace.'\\'.$storeRequestClass,
+            '{{ namespacedUpdateRequest }}' => $namespace.'\\'.$updateRequestClass,
+            '{{namespacedUpdateRequest}}' => $namespace.'\\'.$updateRequestClass,
+            '{{ namespacedRequests }}' => $namespacedRequests,
+            '{{namespacedRequests}}' => $namespacedRequests,
+        ]);
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', null, InputOption::VALUE_NONE, 'Create the class even if the controller already exists'],
+        ];
+    }
+}

--- a/src/Console/Commands/TokenMakeCommand.php
+++ b/src/Console/Commands/TokenMakeCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Laracord\Console\Commands;
+
+use Illuminate\Support\Collection;
+use Laracord\Console\Concerns\ResolvesUser;
+
+class TokenMakeCommand extends Command
+{
+    use ResolvesUser;
+
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'bot:token
+                            {user : The user to generate a token for}
+                            {--regenerate : Regenerate the user\'s token}
+                            {--revoke : Revoke the user\'s token}';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'Generate an API token for the specified user.';
+
+    /**
+     * The user model.
+     *
+     * @var \Illuminate\Database\Eloquent\Model|null
+     */
+    protected $user;
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->user = $this->resolveUser($this->argument('user'));
+
+        if (! $this->user) {
+            return;
+        }
+
+        if ($this->option('regenerate')) {
+            return $this->regenerateToken();
+        }
+
+        if ($this->option('revoke')) {
+            return $this->revokeToken();
+        }
+
+        $this->handleToken();
+    }
+
+    /**
+     * Handle the token generation.
+     */
+    protected function handleToken(bool $force = false): void
+    {
+        $tokens = $this->getTokens();
+
+        if ($tokens->isNotEmpty() && ! $force) {
+            $this->components->error("The user <fg=red>{$this->user->username}</> already has a token.");
+
+            return;
+        }
+
+        $token = $this->user->createToken('token', ['http'])->plainTextToken;
+
+        $this->components->info("The token for <fg=blue>{$this->user->username}</> has been generated.");
+        $this->components->bulletList([$token]);
+    }
+
+    /**
+     * Revoke the user's token.
+     */
+    protected function revokeToken(): void
+    {
+        $tokens = $this->getTokens();
+
+        if ($tokens->isEmpty()) {
+            $this->components->error("The user <fg=red>{$this->user->username}</> does not have a token.");
+
+            return;
+        }
+
+        $tokens->each->delete();
+
+        $this->components->info("The token for <fg=blue>{$this->user->username}</> has been revoked.");
+    }
+
+    /**
+     * Regenerate the user's token.
+     */
+    protected function regenerateToken(): void
+    {
+        $tokens = $this->getTokens();
+
+        if (! $tokens->isEmpty()) {
+            $tokens->each->delete();
+        }
+
+        $this->handleToken(true);
+    }
+
+    /**
+     * Retrieve the user's token(s).
+     */
+    protected function getTokens(): Collection
+    {
+        return $this->user->tokens->filter(fn ($token) => $token->name === 'token');
+    }
+}

--- a/src/Console/Commands/stubs/controller.stub
+++ b/src/Console/Commands/stubs/controller.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace {{ namespace }};
+
+use Laracord\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class {{ class }} extends Controller
+{
+    //
+}

--- a/src/Console/Concerns/ResolvesUser.php
+++ b/src/Console/Concerns/ResolvesUser.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Laracord\Console\Concerns;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+trait ResolvesUser
+{
+    /**
+     * Resolve the user.
+     *
+     * @return \Illuminate\Database\Eloquent\Model|void
+     */
+    protected function resolveUser(?string $user = null)
+    {
+        if (! $user) {
+            $this->components->error('You must specify a valid user.');
+
+            return;
+        }
+
+        if (! is_numeric($user)) {
+            $model = $this->getUserModel()::where('username', $user)->first();
+
+            if (! $model) {
+                $this->components->error("The user <fg=red>{$user}</> does not exist.");
+
+                return;
+            }
+        }
+
+        $model = $model ?? $this->getUserModel()::where('discord_id', $user)->first();
+
+        if (! $model) {
+            $token = $this->getBotClass()::make($this)->getToken();
+
+            $request = Http::withHeaders([
+                'Authorization' => "Bot {$token}",
+            ])->get("https://discord.com/api/users/{$user}");
+
+            if ($request->failed()) {
+                $this->components->error("Failed to fetch user <fg=red>{$user}</> from the Discord API.");
+
+                return;
+            }
+
+            $user = $request->json();
+
+            $model = $this->getUserModel()::updateOrCreate(['discord_id' => $user['id']], [
+                'username' => $user['username'],
+            ]);
+        }
+
+        return $model;
+    }
+
+    /**
+     * Get the bot class.
+     */
+    protected function getBotClass(): string
+    {
+        $class = Str::start($this->app->getNamespace(), '\\').'Bot';
+
+        return class_exists($class) ? $class : 'Laracord';
+    }
+
+    /**
+     * Get the user model class.
+     */
+    protected function getUserModel(): string
+    {
+        $model = Str::start(app()->getNamespace(), '\\').'Models\\User';
+
+        if (! class_exists($model)) {
+            throw new Exception('The user model could not be found.');
+        }
+
+        return $model;
+    }
+}

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laracord\Http\Controllers;
+
+use Discord\DiscordCommandClient as Discord;
+use Illuminate\Routing\Controller as BaseController;
+use Laracord\Console\Commands\Command as ConsoleCommand;
+use Laracord\Laracord;
+
+class Controller extends BaseController
+{
+    /**
+     * The bot instance.
+     */
+    protected ?Laracord $bot;
+
+    /**
+     * Retrieve the bot instance.
+     */
+    public function bot(): Laracord
+    {
+        if ($this->bot) {
+            return $this->bot;
+        }
+
+        return $this->bot = app('bot');
+    }
+
+    /**
+     * Retrieve the Discord instance.
+     */
+    public function discord(): Discord
+    {
+        return $this->bot()->discord();
+    }
+
+    /**
+     * Retrieve the console instance.
+     */
+    public function console(): ConsoleCommand
+    {
+        return $this->bot()->console();
+    }
+}

--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -39,6 +39,7 @@ class Kernel extends HttpKernel
      * @var array<string, class-string|string>
      */
     protected $middlewareAliases = [
+        'auth' => \Laracord\Http\Middleware\EnsureTokenIsValid::class,
         'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
         'precognitive' => \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,

--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Laracord\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    /**
+     * The application's global HTTP middleware stack.
+     *
+     * These middleware are run during every request to your application.
+     *
+     * @var array<int, class-string|string>
+     */
+    protected $middleware = [
+        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
+        \Laracord\Http\Middleware\TrimStrings::class,
+        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+    ];
+
+    /**
+     * The application's route middleware groups.
+     *
+     * @var array<string, array<int, class-string|string>>
+     */
+    protected $middlewareGroups = [
+        'api' => [
+            \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+    ];
+
+    /**
+     * The application's middleware aliases.
+     *
+     * Aliases may be used instead of class names to conveniently assign middleware to routes and groups.
+     *
+     * @var array<string, class-string|string>
+     */
+    protected $middlewareAliases = [
+        'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
+        'precognitive' => \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+    ];
+}

--- a/src/Http/Middleware/EnsureTokenIsValid.php
+++ b/src/Http/Middleware/EnsureTokenIsValid.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Laracord\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class EnsureTokenIsValid
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $token = $request->bearerToken() ?? $request->query('token');
+
+        if (! $token) {
+            return response()->json(['message' => 'You must specify a token.'], 401);
+        }
+
+        $token = PersonalAccessToken::findToken($token);
+
+        if (! $token || ! $token->can('http')) {
+            return response()->json(['message' => 'You are not authorized.'], 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/TrimStrings.php
+++ b/src/Http/Middleware/TrimStrings.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laracord\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\TrimStrings as Middleware;
+
+class TrimStrings extends Middleware
+{
+    /**
+     * The names of the attributes that should not be trimmed.
+     *
+     * @var array<int, string>
+     */
+    protected $except = [
+        'current_password',
+        'password',
+        'password_confirmation',
+    ];
+}

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -117,7 +117,7 @@ class Server
                 return $this->handleError($e);
             }
 
-            if ($response->getStatusCode() !== 200) {
+            if ($response->getStatusCode() !== 200 && app()->isProduction()) {
                 return new Response(
                     $response->getStatusCode(),
                     ['Content-Type' => 'application/json'],

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Laracord\Http;
+
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Laracord\Laracord;
+use Psr\Http\Message\ServerRequestInterface;
+use React\Http\HttpServer;
+use React\Http\Message\Response;
+use React\Socket\SocketServer;
+
+class Server
+{
+    /**
+     * The HTTP server instance.
+     *
+     * @var \React\Http\HttpServer
+     */
+    protected $server;
+
+    /**
+     * The socket server instance.
+     *
+     * @var \React\Socket\SocketServer
+     */
+    protected $socket;
+
+    /**
+     * The server address.
+     */
+    protected string $address = '';
+
+    /**
+     * Determine if the server is booted.
+     */
+    protected bool $booted = false;
+
+    /**
+     * Create a new server instance.
+     *
+     * @return void
+     */
+    public function __construct(Laracord $bot)
+    {
+        $this->bot = $bot;
+    }
+
+    /**
+     * Make a new server instance.
+     */
+    public static function make(Laracord $bot): self
+    {
+        return new static($bot);
+    }
+
+    /**
+     * Boot the HTTP server.
+     */
+    public function boot(): self
+    {
+        if (! $this->getAddress() || ! Route::getRoutes()->getRoutes()) {
+            return $this;
+        }
+
+        $this->socket = new SocketServer($this->getAddress(), [], $this->bot->getLoop());
+
+        $this->getServer()->listen($this->socket);
+
+        $this->booted = true;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the HTTP server instance.
+     *
+     * @return \React\Http\HttpServer
+     */
+    public function getServer()
+    {
+        if ($this->server) {
+            return $this->server;
+        }
+
+        return $this->server = new HttpServer($this->bot->getLoop(), function (ServerRequestInterface $request) {
+            $headers = $request->getHeaders();
+            $request = Request::create($request->getUri()->getPath(), $request->getMethod(), [], [], [], $_SERVER, $request->getBody()->getContents());
+
+            foreach ($headers as $header => $values) {
+                $request->headers->set($header, $values);
+            }
+
+            app()->instance('request', $request);
+
+            $kernel = class_exists($kernel = Str::start(app()->getNamespace(), '\\').'Http\\Kernel')
+                ? app()->make($kernel)
+                : app()->make(Kernel::class);
+
+            if ($this->bot->prependMiddleware()) {
+                foreach ($this->bot->prependMiddleware() as $middleware) {
+                    $kernel->prependMiddleware($middleware);
+                }
+            }
+
+            if ($this->bot->middleware()) {
+                foreach ($this->bot->middleware() as $middleware) {
+                    $kernel->pushMiddleware($middleware);
+                }
+            }
+
+            try {
+                $response = $kernel->handle($request);
+            } catch (Throwable $e) {
+                return $this->handleError($e);
+            }
+
+            if ($response->getStatusCode() !== 200) {
+                return new Response(
+                    $response->getStatusCode(),
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['status' => $response->getStatusCode()])
+                );
+            }
+
+            return new Response(
+                $response->getStatusCode(),
+                $response->headers->allPreserveCaseWithoutCookies(),
+                $response->getContent()
+            );
+        });
+    }
+
+    /**
+     * Handle an error response.
+     */
+    protected function handleError(Throwable $e): Response
+    {
+        $response = 'Internal Server Error';
+
+        if (! app()->isProduction()) {
+            $response = Str::finish($response, ": {$e->getMessage()}");
+        }
+
+        $this->bot->console()->error($e->getMessage());
+
+        return new Response(
+            500,
+            ['Content-Type' => 'application/json'],
+            json_encode(['code' => 500, 'message' => $response])
+        );
+    }
+
+    /**
+     * Retrieve the socket server instance.
+     *
+     * @return \React\Socket\SocketServer
+     */
+    public function getSocket()
+    {
+        return $this->socket;
+    }
+
+    /**
+     * Retrieve the server address.
+     */
+    public function getAddress(): ?string
+    {
+        if ($this->address) {
+            return $this->address;
+        }
+
+        $address = config('discord.http');
+
+        if (! $address) {
+            return null;
+        }
+
+        if (Str::startsWith($address, ':')) {
+            $address = Str::start($address, '0.0.0.0');
+        }
+
+        $host = Str::before($address, ':');
+        $port = Str::after($address, ':');
+
+        if (! filter_var($host, FILTER_VALIDATE_IP)) {
+            throw new Exception('Invalid HTTP server address');
+        }
+
+        if ($port > 65535 || $port < 1) {
+            throw new Exception('Invalid HTTP server port');
+        }
+
+        return $this->address = $address;
+    }
+
+    /**
+     * Determine if the server is booted.
+     */
+    public function isBooted(): bool
+    {
+        return $this->booted;
+    }
+}

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -87,7 +87,7 @@ class Server
 
         return $this->server = new HttpServer($this->bot->getLoop(), function (ServerRequestInterface $request) {
             $headers = $request->getHeaders();
-            $request = Request::create($request->getUri()->getPath(), $request->getMethod(), [], [], [], $_SERVER, $request->getBody()->getContents());
+            $request = Request::create($request->getUri()->getPath(), $request->getMethod(), $request->getQueryParams(), [], [], $_SERVER, $request->getBody()->getContents());
 
             foreach ($headers as $header => $values) {
                 $request->headers->set($header, $values);

--- a/src/Laracord.php
+++ b/src/Laracord.php
@@ -484,17 +484,17 @@ class Laracord
     /**
      * Boot the HTTP server.
      */
-    public function bootHttpServer(): void
+    public function bootHttpServer(): self
     {
         if ($this->httpServer) {
-            return;
+            return $this;
         }
 
         $address = config('discord.http');
         $routes = $this->getHttpPath('routes.php');
 
         if (! $address || ! File::exists($routes)) {
-            return;
+            return $this;
         }
 
         if (Str::startsWith($address, ':')) {
@@ -504,7 +504,7 @@ class Laracord
         require_once $routes;
 
         if (! Route::getRoutes()->getRoutes()) {
-            return;
+            return $this;
         }
 
         $this->httpServer = new HttpServer($this->getLoop(), function (ServerRequestInterface $request) {
@@ -541,6 +541,8 @@ class Laracord
         $this->httpServer->listen($socket);
 
         $this->console()->log("HTTP server started on <fg=blue>{$address}</>.");
+
+        return $this;
     }
 
     /**

--- a/src/Laracord.php
+++ b/src/Laracord.php
@@ -21,6 +21,7 @@ use Laracord\Services\Service;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\HttpServer;
+use React\Http\Message\Response;
 use React\Socket\SocketServer;
 use ReflectionClass;
 use Throwable;
@@ -479,10 +480,6 @@ class Laracord
         }
 
         $this->httpServer = new HttpServer($this->getLoop(), function (ServerRequestInterface $request) {
-            if (! in_array($request->getMethod(), ['GET', 'POST'])) {
-                return response()->json(['error' => 'Method not allowed.'], 405);
-            }
-
             $headers = $request->getHeaders();
             $request = Request::create($request->getUri()->getPath(), $request->getMethod(), [], [], [], $_SERVER, $request->getBody()->getContents());
 
@@ -501,10 +498,10 @@ class Laracord
                     $response = Str::finish($response, ": {$e->getMessage()}");
                 }
 
-                return response()->json(['error' => $response], 500);
+                return new Response(500, ['Content-Type' => 'text/plain'], $response);
             }
 
-            return response(
+            return new Response(
                 $response->getStatusCode(),
                 $response->headers->allPreserveCaseWithoutCookies(),
                 $response->getContent()

--- a/src/LaracordServiceProvider.php
+++ b/src/LaracordServiceProvider.php
@@ -94,6 +94,7 @@ class LaracordServiceProvider extends ServiceProvider
             Console\Commands\MakeCommand::class,
             Console\Commands\MakeSlashCommand::class,
             Console\Commands\ModelMakeCommand::class,
+            Console\Commands\TokenMakeCommand::class,
             Console\Commands\ServiceMakeCommand::class,
         ]);
 

--- a/src/LaracordServiceProvider.php
+++ b/src/LaracordServiceProvider.php
@@ -88,6 +88,7 @@ class LaracordServiceProvider extends ServiceProvider
         $this->commands([
             Console\Commands\AdminCommand::class,
             Console\Commands\BootCommand::class,
+            Console\Commands\ControllerMakeCommand::class,
             Console\Commands\ConsoleMakeCommand::class,
             Console\Commands\EventMakeCommand::class,
             Console\Commands\MakeCommand::class,

--- a/src/LaracordServiceProvider.php
+++ b/src/LaracordServiceProvider.php
@@ -47,6 +47,9 @@ class LaracordServiceProvider extends ServiceProvider
 
             return new PsrHttpFactory($factory, $factory, $factory, $factory);
         });
+
+        $this->app['config']->set('app.debug', ! $this->app->isProduction());
+        $this->app['config']->set('view.paths', []);
     }
 
     /**

--- a/src/LaracordServiceProvider.php
+++ b/src/LaracordServiceProvider.php
@@ -2,7 +2,14 @@
 
 namespace Laracord;
 
+use Illuminate\Http\Request;
+use Illuminate\Routing\RoutingServiceProvider;
+use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\View\ViewServiceProvider;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 
 class LaracordServiceProvider extends ServiceProvider
 {
@@ -17,6 +24,29 @@ class LaracordServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/commands.php', 'commands');
         $this->mergeConfigFrom(__DIR__.'/../config/database.php', 'database');
         $this->mergeConfigFrom(__DIR__.'/../config/discord.php', 'discord');
+
+        if ($this->isRoutingEnabled()) {
+            $this->registerRouting();
+        }
+    }
+
+    /**
+     * Register routing support for the application.
+     *
+     * @return void
+     */
+    public function registerRouting()
+    {
+        $this->app->register(RoutingServiceProvider::class);
+        $this->app->register(ViewServiceProvider::class);
+
+        $this->app->singleton('psr17Factory', fn () => new Psr17Factory());
+        $this->app->singleton('httpFoundationFactory', fn () => new HttpFoundationFactory());
+        $this->app->singleton('psrHttpFactory', function () {
+            $factory = $this->app->make('psr17Factory');
+
+            return new PsrHttpFactory($factory, $factory, $factory, $factory);
+        });
     }
 
     /**
@@ -36,5 +66,39 @@ class LaracordServiceProvider extends ServiceProvider
             Console\Commands\ModelMakeCommand::class,
             Console\Commands\ServiceMakeCommand::class,
         ]);
+
+        if ($this->isRoutingEnabled()) {
+            $this->bootRouting();
+        }
+    }
+
+    /**
+     * Bootstrap the routing services for the application.
+     *
+     * @return void
+     */
+    public function bootRouting()
+    {
+        $psr17 = $this->app->make('psr17Factory');
+        $foundation = $this->app->make('httpFoundationFactory');
+
+        $request = Request::createFromBase(
+            $foundation->createRequest(
+                $psr17->createServerRequest('GET', '/')
+            )
+        );
+
+        $this->app->instance('request', $request);
+        $this->app->instance('url', new UrlGenerator($this->app['router']->getRoutes(), $this->app['request']));
+    }
+
+    /**
+     * Determine if routing is enabled for the application.
+     *
+     * @return bool
+     */
+    public function isRoutingEnabled()
+    {
+        return (bool) $this->app['config']->get('discord.http');
     }
 }

--- a/src/Logging/Logger.php
+++ b/src/Logging/Logger.php
@@ -17,6 +17,7 @@ class Logger implements LoggerInterface
         'sending heartbeat',
         'received heartbeat',
         'http not checking',
+        'resetting payload count',
     ];
 
     /**


### PR DESCRIPTION
This is an initial HTTP server implementation for `react/http` with full Laravel routing support. This will allow you to create webhooks and an API to interact with your bot.

## Remaining Changes

- [x] Extract into an override-able Kernel.
- [x] Add sane default middleware (`ConvertEmptyStringsToNull`, `TrimStrings`, rate limiting, etc.)
- [x] Add API token support (`bot:token` generator command, default `auth` middleware, etc.)
- [x] Implement support for Controllers and `make:controller` for complex routes.
- [x] Decide on final directory structure when used in Laracord.

## Testing

If you would like to help test this PR as-is, you can try it out with the following:

```sh
composer create-project laracord/laracord
cd laracord
composer require laracord/framework:dev-feat/21
```

**app/Bot.php**
```php
<?php

namespace App;

use Illuminate\Support\Facades\Route;
use Laracord\Laracord;

class Bot extends Laracord
{
    /**
     * The HTTP routes.
     */
    public function routes(): void
    {
        Route::get('/', fn () => collect(Route::getRoutes()->getRoutes())->map(fn ($route) => $route->uri));

        Route::get('/commands', fn () => collect($this->registeredCommands)->map(fn ($command) => [
            'signature' => $command->getSignature(),
            'description' => $command->getDescription(),
        ]));

        Route::get('/servers', fn () => $this->discord()->guilds->map(fn ($server) => [
            'id' => $server->id,
            'name' => $server->name,
        ]));

        Route::get('/channels/{server}', fn ($server) => $this->discord()->guilds->get('id', $server)?->channels->map(fn ($channel) => [
            'id' => $channel->id,
            'name' => $channel->name,
        ]) ?? ['message' => 'Server not found.']);

        Route::get('/message', function () {
            $this
                ->message('This is a message from the HTTP server.')
                ->title('Hello from HTTP land!')
                ->send('your-channel-id');

            return ['message' => 'Message sent!'];
        });
    }
}
```

Once you boot your bot, it will be accessible at `localhost:8080` by default.

![Screenshot](https://i.imgur.com/b9IFcnG.png)

Out of the box, it also includes the Symfony error handler when in local/development:

![Exceptions Screenshot](https://i.imgur.com/QfVtk0q.png)
