### PR TITLE
✨ Add Livewire support to the HTTP server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "guzzlehttp/guzzle": "^7.5",
     "illuminate/database": "^10.0",
     "illuminate/http": "^10.0",
+    "illuminate/queue": "^10.0",
     "illuminate/routing": "^10.0",
     "illuminate/translation": "^10.0",
     "laravel-zero/framework": "^10.2",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "illuminate/queue": "^10.0",
     "illuminate/routing": "^10.0",
     "illuminate/translation": "^10.0",
+    "illuminate/validation": "^10.0",
     "laravel-zero/framework": "^10.2",
     "laravel/sanctum": "^3.3",
     "nunomaduro/termwind": "^1.15.1",

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "php": "^8.1",
     "guzzlehttp/guzzle": "^7.5",
     "illuminate/database": "^10.0",
+    "illuminate/encryption": "^10.0",
     "illuminate/http": "^10.0",
     "illuminate/queue": "^10.0",
     "illuminate/routing": "^10.0",

--- a/config/app.php
+++ b/config/app.php
@@ -4,6 +4,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Debug Mode
+    |--------------------------------------------------------------------------
+    |
+    | When your application is in debug mode, detailed error messages with
+    | stack traces will be shown on every error that occurs within your
+    | application. If disabled, a simple generic error page is shown.
+    |
+    */
+
+    'debug' => env('APP_ENV', 'production') !== 'production',
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Locale Configuration
     |--------------------------------------------------------------------------
     |
@@ -30,15 +43,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Application Debug Mode
+    | Encryption Key
     |--------------------------------------------------------------------------
     |
-    | When your application is in debug mode, detailed error messages with
-    | stack traces will be shown on every error that occurs within your
-    | application. If disabled, a simple generic error page is shown.
+    | This key is used by the Illuminate encrypter service and should be set
+    | to a random, 32 character string, otherwise these encrypted strings
+    | will not be safe. Please do this before deploying an application!
     |
     */
 
-    'debug' => env('APP_ENV', 'production') !== 'production',
+    'key' => env('APP_KEY'),
+
+    'cipher' => 'AES-256-CBC',
 
 ];

--- a/config/cache.php
+++ b/config/cache.php
@@ -32,9 +32,10 @@ return [
     'stores' => [
         'file' => [
             'driver' => 'file',
-            'path' => config('app.env') === 'production' ?
-                env('CACHE_PATH', getcwd().'/cache') :
-                env('CACHE_PATH', base_path('cache')),
+            'path' => env('CACHE_PATH', config('app.env') === 'production'
+                ? getcwd().'/cache'
+                : base_path('cache')
+            ),
         ],
     ],
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -1,0 +1,44 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Filesystem Disk
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the default filesystem disk that should be used
+    | by the framework. The "local" disk, as well as a variety of cloud
+    | based disks are available to your application. Just store away!
+    |
+    */
+
+    'default' => env('FILESYSTEM_DISK', 'local'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filesystem Disks
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure as many filesystem "disks" as you wish, and you
+    | may even configure multiple disks of the same driver. Defaults have
+    | been set up for each driver as an example of the required values.
+    |
+    | Supported Drivers: "local"
+    |
+    */
+
+    'disks' => [
+
+        'local' => [
+            'driver' => 'local',
+            'root' => env('STORAGE_PATH', config('app.env') === 'production'
+                ? getcwd().'/storage'
+                : base_path('storage')
+            ),
+            'throw' => false,
+        ],
+
+    ],
+
+];

--- a/config/session.php
+++ b/config/session.php
@@ -1,0 +1,214 @@
+<?php
+
+use Illuminate\Support\Str;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Session Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default session "driver" that will be used on
+    | requests. By default, we will use the lightweight native driver but
+    | you may specify any of the other wonderful drivers provided here.
+    |
+    | Supported: "file", "cookie", "database", "apc",
+    |            "memcached", "redis", "dynamodb", "array"
+    |
+    */
+
+    'driver' => env('SESSION_DRIVER', 'file'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Lifetime
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the number of minutes that you wish the session
+    | to be allowed to remain idle before it expires. If you want them
+    | to immediately expire on the browser closing, set that option.
+    |
+    */
+
+    'lifetime' => env('SESSION_LIFETIME', 120),
+
+    'expire_on_close' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Encryption
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to easily specify that all of your session data
+    | should be encrypted before it is stored. All encryption will be run
+    | automatically by Laravel and you can use the Session like normal.
+    |
+    */
+
+    'encrypt' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session File Location
+    |--------------------------------------------------------------------------
+    |
+    | When using the native session driver, we need a location where session
+    | files may be stored. A default has been set for you but a different
+    | location may be specified. This is only needed for file sessions.
+    |
+    */
+
+    'files' => base_path('cache/sessions'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | When using the "database" or "redis" session drivers, you may specify a
+    | connection that should be used to manage these sessions. This should
+    | correspond to a connection in your database configuration options.
+    |
+    */
+
+    'connection' => env('SESSION_CONNECTION'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Database Table
+    |--------------------------------------------------------------------------
+    |
+    | When using the "database" session driver, you may specify the table we
+    | should use to manage the sessions. Of course, a sensible default is
+    | provided for you; however, you are free to change this as needed.
+    |
+    */
+
+    'table' => 'sessions',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Cache Store
+    |--------------------------------------------------------------------------
+    |
+    | While using one of the framework's cache driven session backends you may
+    | list a cache store that should be used for these sessions. This value
+    | must match with one of the application's configured cache "stores".
+    |
+    | Affects: "apc", "dynamodb", "memcached", "redis"
+    |
+    */
+
+    'store' => env('SESSION_STORE'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Sweeping Lottery
+    |--------------------------------------------------------------------------
+    |
+    | Some session drivers must manually sweep their storage location to get
+    | rid of old sessions from storage. Here are the chances that it will
+    | happen on a given request. By default, the odds are 2 out of 100.
+    |
+    */
+
+    'lottery' => [2, 100],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Cookie Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may change the name of the cookie used to identify a session
+    | instance by ID. The name specified here will get used every time a
+    | new session cookie is created by the framework for every driver.
+    |
+    */
+
+    'cookie' => env(
+        'SESSION_COOKIE',
+        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Cookie Path
+    |--------------------------------------------------------------------------
+    |
+    | The session cookie path determines the path for which the cookie will
+    | be regarded as available. Typically, this will be the root path of
+    | your application but you are free to change this when necessary.
+    |
+    */
+
+    'path' => '/',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Cookie Domain
+    |--------------------------------------------------------------------------
+    |
+    | Here you may change the domain of the cookie used to identify a session
+    | in your application. This will determine which domains the cookie is
+    | available to in your application. A sensible default has been set.
+    |
+    */
+
+    'domain' => env('SESSION_DOMAIN'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | HTTPS Only Cookies
+    |--------------------------------------------------------------------------
+    |
+    | By setting this option to true, session cookies will only be sent back
+    | to the server if the browser has a HTTPS connection. This will keep
+    | the cookie from being sent to you when it can't be done securely.
+    |
+    */
+
+    'secure' => env('SESSION_SECURE_COOKIE'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | HTTP Access Only
+    |--------------------------------------------------------------------------
+    |
+    | Setting this value to true will prevent JavaScript from accessing the
+    | value of the cookie and the cookie will only be accessible through
+    | the HTTP protocol. You are free to modify this option if needed.
+    |
+    */
+
+    'http_only' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Same-Site Cookies
+    |--------------------------------------------------------------------------
+    |
+    | This option determines how your cookies behave when cross-site requests
+    | take place, and can be used to mitigate CSRF attacks. By default, we
+    | will set this value to "lax" since this is a secure default value.
+    |
+    | Supported: "lax", "strict", "none", null
+    |
+    */
+
+    'same_site' => 'lax',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Partitioned Cookies
+    |--------------------------------------------------------------------------
+    |
+    | Setting this value to true will tie the cookie to the top-level site for
+    | a cross-site context. Partitioned cookies are accepted by the browser
+    | when flagged "secure" and the Same-Site attribute is set to "none".
+    |
+    */
+
+    'partitioned' => false,
+
+];

--- a/config/session.php
+++ b/config/session.php
@@ -59,7 +59,9 @@ return [
     |
     */
 
-    'files' => base_path('cache/sessions'),
+    'files' => config('app.env') === 'production'
+        ? getcwd().'/cache/sessions'
+        : base_path('cache/sessions'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/view.php
+++ b/config/view.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | View Storage Paths
+    |--------------------------------------------------------------------------
+    |
+    | Most templating systems load templates from disk. Here you may specify
+    | an array of paths that should be checked for your views. Of course
+    | the usual Laravel view path has already been registered for you.
+    |
+    */
+
+    'paths' => [
+        resource_path('views'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Compiled View Path
+    |--------------------------------------------------------------------------
+    |
+    | This option determines where all the compiled Blade templates will be
+    | stored for your application. Typically, this is within the storage
+    | directory. However, as usual, you are free to change this value.
+    |
+    */
+
+    'compiled' => env(
+        'VIEW_COMPILED_PATH',
+        realpath(
+            env('CACHE_PATH', config('app.env') === 'production'
+                ? getcwd().'/cache'
+                : base_path('cache')
+            ).'/views'
+        )
+    ),
+
+];

--- a/config/view.php
+++ b/config/view.php
@@ -28,14 +28,8 @@ return [
     |
     */
 
-    'compiled' => env(
-        'VIEW_COMPILED_PATH',
-        realpath(
-            env('CACHE_PATH', config('app.env') === 'production'
-                ? getcwd().'/cache'
-                : base_path('cache')
-            ).'/views'
-        )
-    ),
+    'compiled' => config('app.env') === 'production'
+        ? getcwd().'/cache/views'
+        : base_path('cache/views'),
 
 ];

--- a/src/Console/Commands/BootCommand.php
+++ b/src/Console/Commands/BootCommand.php
@@ -46,8 +46,10 @@ class BootCommand extends Command
     protected function handleCache(): void
     {
         $cache = config('cache.stores.file.path');
+        $session = config('session.files');
 
         File::ensureDirectoryExists($cache);
+        File::ensureDirectoryExists($session);
     }
 
     /**

--- a/src/Console/Commands/BootCommand.php
+++ b/src/Console/Commands/BootCommand.php
@@ -2,7 +2,6 @@
 
 namespace Laracord\Console\Commands;
 
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 
 class BootCommand extends Command
@@ -33,23 +32,9 @@ class BootCommand extends Command
             $this->callSilent('migrate', ['--force' => true]);
         }
 
-        $this->handleCache();
-
         $this->app->singleton('bot', fn () => $this->getClass()::make($this));
 
         $this->app->make('bot')->boot();
-    }
-
-    /**
-     * Handle the cache.
-     */
-    protected function handleCache(): void
-    {
-        $cache = config('cache.stores.file.path');
-        $session = config('session.files');
-
-        File::ensureDirectoryExists($cache);
-        File::ensureDirectoryExists($session);
     }
 
     /**

--- a/src/Console/Commands/KeyGenerateCommand.php
+++ b/src/Console/Commands/KeyGenerateCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laracord\Console\Commands;
+
+use Illuminate\Foundation\Console\KeyGenerateCommand as FoundationKeyGenerateCommand;
+use Illuminate\Support\Facades\File;
+
+class KeyGenerateCommand extends FoundationKeyGenerateCommand
+{
+    /**
+     * Write a new environment file with the given key.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function writeNewEnvironmentFileWith($key)
+    {
+        $envFile = $this->laravel->environmentFilePath();
+
+        if (! $envFile) {
+            $this->error('Unable to set application key. Create a .env file.');
+
+            return false;
+        }
+
+        if ($this->replace($envFile, $key)) {
+            return true;
+        }
+
+        if ($this->prepend($envFile, $key)) {
+            return true;
+        }
+
+        $this->error('Unable to set application key.');
+
+        return false;
+    }
+
+    protected function replace($envFile, $key): bool
+    {
+        $replaced = preg_replace(
+            $this->keyReplacementPattern(),
+            'APP_KEY='.$key,
+            $input = file_get_contents($envFile)
+        );
+
+        if ($replaced === $input || $replaced === null) {
+            return false;
+        }
+
+        return file_put_contents($envFile, $replaced) !== false;
+    }
+
+    protected function prepend($envFile, $key): bool
+    {
+        return File::prepend($envFile, 'APP_KEY='.$key.PHP_EOL) !== false;
+    }
+}

--- a/src/HasLaracord.php
+++ b/src/HasLaracord.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Laracord;
+
+use Discord\DiscordCommandClient as Discord;
+use Laracord\Console\Commands\Command as ConsoleCommand;
+use Laracord\Discord\Message;
+
+trait HasLaracord
+{
+    /**
+     * The bot instance.
+     */
+    protected ?Laracord $bot;
+
+    /**
+     * Retrieve the bot instance.
+     */
+    public function bot(): Laracord
+    {
+        if ($this->bot) {
+            return $this->bot;
+        }
+
+        return $this->bot = app('bot');
+    }
+
+    /**
+     * Retrieve the Discord instance.
+     */
+    public function discord(): Discord
+    {
+        return $this->bot()->discord();
+    }
+
+    /**
+     * Retrieve the console instance.
+     */
+    public function console(): ConsoleCommand
+    {
+        return $this->bot()->console();
+    }
+
+    /**
+     * Build an embed for use in a Discord message.
+     *
+     * @param  string  $content
+     * @return \Laracord\Discord\Message
+     */
+    public function message($content = '')
+    {
+        return Message::make($this)
+            ->content($content);
+    }
+}

--- a/src/HasLaracord.php
+++ b/src/HasLaracord.php
@@ -11,7 +11,7 @@ trait HasLaracord
     /**
      * The bot instance.
      */
-    protected ?Laracord $bot;
+    protected ?Laracord $bot = null;
 
     /**
      * Retrieve the bot instance.
@@ -49,7 +49,7 @@ trait HasLaracord
      */
     public function message($content = '')
     {
-        return Message::make($this)
+        return Message::make($this->bot())
             ->content($content);
     }
 }

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -2,43 +2,10 @@
 
 namespace Laracord\Http\Controllers;
 
-use Discord\DiscordCommandClient as Discord;
 use Illuminate\Routing\Controller as BaseController;
-use Laracord\Console\Commands\Command as ConsoleCommand;
-use Laracord\Laracord;
+use Laracord\HasLaracord;
 
 class Controller extends BaseController
 {
-    /**
-     * The bot instance.
-     */
-    protected ?Laracord $bot;
-
-    /**
-     * Retrieve the bot instance.
-     */
-    public function bot(): Laracord
-    {
-        if ($this->bot) {
-            return $this->bot;
-        }
-
-        return $this->bot = app('bot');
-    }
-
-    /**
-     * Retrieve the Discord instance.
-     */
-    public function discord(): Discord
-    {
-        return $this->bot()->discord();
-    }
-
-    /**
-     * Retrieve the console instance.
-     */
-    public function console(): ConsoleCommand
-    {
-        return $this->bot()->console();
-    }
+    use HasLaracord;
 }

--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -25,6 +25,12 @@ class Kernel extends HttpKernel
      * @var array<string, array<int, class-string|string>>
      */
     protected $middlewareGroups = [
+        'web' => [
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+
         'api' => [
             \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/src/Http/Providers/RouteServiceProvider.php
+++ b/src/Http/Providers/RouteServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laracord\Http\Providers;
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    /**
+     * Define your route model bindings, pattern filters, and other route configuration.
+     */
+    public function boot(): void
+    {
+        RateLimiter::for('api', function (Request $request) {
+            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+        });
+    }
+}

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -128,7 +128,7 @@ class Server
             return new Response(
                 $response->getStatusCode(),
                 $response->headers->allPreserveCaseWithoutCookies(),
-                $response->getContent()
+                $response->getContent() ?: $response->getFile()?->getContent()
             );
         });
     }

--- a/src/Laracord.php
+++ b/src/Laracord.php
@@ -11,9 +11,9 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Laracord\Commands\Command;
-use Laracord\Commands\Components\Message;
 use Laracord\Commands\SlashCommand;
 use Laracord\Console\Commands\Command as ConsoleCommand;
+use Laracord\Discord\Message;
 use Laracord\Events\Event;
 use Laracord\Http\Server;
 use Laracord\Logging\Logger;
@@ -853,7 +853,7 @@ class Laracord
      * Build an embed for use in a Discord message.
      *
      * @param  string  $content
-     * @return \Laracord\Commands\Components\Message
+     * @return \Laracord\Discord\Message
      */
     public function message($content = '')
     {

--- a/src/LaracordServiceProvider.php
+++ b/src/LaracordServiceProvider.php
@@ -57,14 +57,15 @@ class LaracordServiceProvider extends ServiceProvider
         $this->commands([
             Console\Commands\AdminCommand::class,
             Console\Commands\BootCommand::class,
-            Console\Commands\ControllerMakeCommand::class,
             Console\Commands\ConsoleMakeCommand::class,
+            Console\Commands\ControllerMakeCommand::class,
             Console\Commands\EventMakeCommand::class,
+            Console\Commands\KeyGenerateCommand::class,
             Console\Commands\MakeCommand::class,
             Console\Commands\MakeSlashCommand::class,
             Console\Commands\ModelMakeCommand::class,
-            Console\Commands\TokenMakeCommand::class,
             Console\Commands\ServiceMakeCommand::class,
+            Console\Commands\TokenMakeCommand::class,
         ]);
     }
 }

--- a/src/LaracordServiceProvider.php
+++ b/src/LaracordServiceProvider.php
@@ -2,22 +2,28 @@
 
 namespace Laracord;
 
-use Illuminate\Cache\RateLimiting\Limit;
-use Illuminate\Http\Request;
-use Illuminate\Routing\RoutingServiceProvider;
-use Illuminate\Routing\UrlGenerator;
-use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Contracts\Http\Kernel as KernelContract;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Translation\FileLoader;
-use Illuminate\Translation\TranslationServiceProvider;
-use Illuminate\Translation\Translator;
-use Illuminate\View\ViewServiceProvider;
-use Nyholm\Psr7\Factory\Psr17Factory;
-use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
-use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Laracord\Http\Kernel;
 
 class LaracordServiceProvider extends ServiceProvider
 {
+    /**
+     * The default providers.
+     *
+     * @var array
+     */
+    protected $providers = [
+        \Illuminate\Routing\RoutingServiceProvider::class,
+        \Illuminate\View\ViewServiceProvider::class,
+        \Illuminate\Encryption\EncryptionServiceProvider::class,
+        \Illuminate\Session\SessionServiceProvider::class,
+        \Illuminate\Validation\ValidationServiceProvider::class,
+        \Illuminate\Queue\QueueServiceProvider::class,
+        \Illuminate\Translation\TranslationServiceProvider::class,
+        \Laracord\Http\Providers\RouteServiceProvider::class,
+    ];
+
     /**
      * Register any application services.
      *
@@ -30,52 +36,15 @@ class LaracordServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/commands.php', 'commands');
         $this->mergeConfigFrom(__DIR__.'/../config/database.php', 'database');
         $this->mergeConfigFrom(__DIR__.'/../config/discord.php', 'discord');
+        $this->mergeConfigFrom(__DIR__.'/../config/filesystems.php', 'filesystems');
+        $this->mergeConfigFrom(__DIR__.'/../config/session.php', 'session');
+        $this->mergeConfigFrom(__DIR__.'/../config/view.php', 'view');
 
-        $this->registerTranslations();
-
-        if ($this->isRoutingEnabled()) {
-            $this->registerRouting();
+        foreach ($this->providers as $provider) {
+            $this->app->register($provider);
         }
-    }
 
-    /**
-     * Register translations for the application.
-     *
-     * @return void
-     */
-    public function registerTranslations()
-    {
-        $this->app->register(TranslationServiceProvider::class);
-
-        $this->app->singleton('translator', function ($app) {
-            $loader = new FileLoader($app['files'], $app['path.lang']);
-            $translator = new Translator($loader, $app['config']['app.locale']);
-            $translator->setFallback($app['config']['app.fallback_locale']);
-
-            return $translator;
-        });
-    }
-
-    /**
-     * Register routing support for the application.
-     *
-     * @return void
-     */
-    public function registerRouting()
-    {
-        $this->app->register(RoutingServiceProvider::class);
-        $this->app->register(ViewServiceProvider::class);
-
-        $this->app->singleton('psr17Factory', fn () => new Psr17Factory());
-        $this->app->singleton('httpFoundationFactory', fn () => new HttpFoundationFactory());
-        $this->app->singleton('psrHttpFactory', function () {
-            $factory = $this->app->make('psr17Factory');
-
-            return new PsrHttpFactory($factory, $factory, $factory, $factory);
-        });
-
-        $this->app['config']->set('view.paths', []);
-        $this->app['config']->set('view.compiled', $this->app['config']->get('cache.stores.file.path', base_path('cache')).'/views');
+        $this->app->singleton(KernelContract::class, Kernel::class);
     }
 
     /**
@@ -97,41 +66,5 @@ class LaracordServiceProvider extends ServiceProvider
             Console\Commands\TokenMakeCommand::class,
             Console\Commands\ServiceMakeCommand::class,
         ]);
-
-        if ($this->isRoutingEnabled()) {
-            $this->bootRouting();
-        }
-    }
-
-    /**
-     * Bootstrap the routing services for the application.
-     *
-     * @return void
-     */
-    public function bootRouting()
-    {
-        $psr17 = $this->app->make('psr17Factory');
-        $foundation = $this->app->make('httpFoundationFactory');
-
-        $request = Request::createFromBase(
-            $foundation->createRequest(
-                $psr17->createServerRequest('GET', '/')
-            )
-        );
-
-        $this->app->instance('request', $request);
-        $this->app->instance('url', new UrlGenerator($this->app['router']->getRoutes(), $this->app['request']));
-
-        RateLimiter::for('api', fn ($request) => Limit::perMinute(60)->by($request->ip()));
-    }
-
-    /**
-     * Determine if routing is enabled for the application.
-     *
-     * @return bool
-     */
-    public function isRoutingEnabled()
-    {
-        return (bool) $this->app['config']->get('discord.http');
     }
 }

--- a/src/LaracordServiceProvider.php
+++ b/src/LaracordServiceProvider.php
@@ -40,6 +40,18 @@ class LaracordServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/session.php', 'session');
         $this->mergeConfigFrom(__DIR__.'/../config/view.php', 'view');
 
+        $paths = [
+            'cache' => $this->app['config']->get('cache.stores.file.path'),
+            'session' => $this->app['config']->get('session.files'),
+            'view' => $this->app['config']->get('view.compiled'),
+        ];
+
+        foreach ($paths as $path) {
+            if (! is_dir($path)) {
+                mkdir($path, 0755, true);
+            }
+        }
+
         foreach ($this->providers as $provider) {
             $this->app->register($provider);
         }


### PR DESCRIPTION
This PR finalizes the ReactPHP HTTP server/routing implementation adding support for [Livewire 3](https://livewire.laravel.com/).

## Usage

Generate an application key:

```sh
$ php laracord key:generate
```

Install Livewire:

```sh
$ composer require livewire/livewire
```

Add the Livewire provider to `config/app.php`:

```php
/*
|--------------------------------------------------------------------------
| Autoloaded Service Providers
|--------------------------------------------------------------------------
|
| The service providers listed here will be automatically loaded on the
| request to your application. Feel free to add your own services to
| this array to grant expanded functionality to your applications.
|
*/

'providers' => [
    App\Providers\BotServiceProvider::class,
    Livewire\LivewireServiceProvider::class,
],
```

Afterwards, you should be able to create a Livewire app layout/components and register them inside of `routes()` in `app/Bot.php`.