### PR TITLE
✨ Add input/output stream support

### DIFF
--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -15,6 +15,13 @@ use React\Socket\SocketServer;
 class Server
 {
     /**
+     * The Laracord instance.
+     *
+     * @var \Laracord\Laracord
+     */
+    protected $bot;
+
+    /**
      * The HTTP server instance.
      *
      * @var \React\Http\HttpServer
@@ -72,6 +79,23 @@ class Server
         $this->booted = true;
 
         return $this;
+    }
+
+    /**
+     * Shutdown the HTTP server.
+     */
+    public function shutdown(): void
+    {
+        if (! $this->isBooted()) {
+            return;
+        }
+
+        $this->getServer()->removeAllListeners();
+        $this->getSocket()->close();
+
+        $this->booted = false;
+
+        $this->bot->console()->log('The HTTP server has been shutdown');
     }
 
     /**

--- a/src/Laracord.php
+++ b/src/Laracord.php
@@ -19,6 +19,8 @@ use Laracord\Http\Server;
 use Laracord\Logging\Logger;
 use Laracord\Services\Service;
 use React\EventLoop\Loop;
+use React\Stream\ReadableResourceStream;
+use React\Stream\WritableResourceStream;
 use ReflectionClass;
 
 use function Laravel\Prompts\table;
@@ -103,9 +105,23 @@ class Laracord
     protected array $services = [];
 
     /**
+     * The console input stream.
+     *
+     * @var \React\Stream\ReadableResourceStream
+     */
+    protected $inputStream;
+
+    /**
+     * The console output stream.
+     *
+     * @var \React\Stream\WritableResourceStream
+     */
+    protected $outputStream;
+
+    /**
      * The bot HTTP server.
      *
-     * @var \React\Http\HttpServer
+     * @var \Laracord\Http\Server
      */
     protected $httpServer;
 
@@ -160,6 +176,8 @@ class Laracord
 
         $this->bootDiscord();
 
+        $this->registerStream();
+
         $this->registerCommands();
 
         $this->discord()->on('ready', function () {
@@ -173,6 +191,7 @@ class Laracord
                 'command' => count($this->registeredCommands),
                 'event' => count($this->registeredEvents),
                 'service' => count($this->registeredServices),
+                'routes' => count(Route::getRoutes()->getRoutes()),
             ])
                 ->filter()
                 ->map(function ($count, $type) {
@@ -189,6 +208,8 @@ class Laracord
                 ->showCommands()
                 ->showInvite()
                 ->afterBoot();
+
+            $this->outputStream->write('> ');
         });
 
         $this->discord()->run();
@@ -206,6 +227,89 @@ class Laracord
             'discordOptions' => $this->getOptions(),
             'defaultHelpCommand' => false,
         ]);
+    }
+
+    /**
+     * Register the input and output streams.
+     */
+    public function registerStream(): self
+    {
+        if ($this->inputStream && $this->outputStream) {
+            return $this;
+        }
+
+        $this->inputStream = new ReadableResourceStream(STDIN, $this->getLoop());
+        $this->outputStream = new WritableResourceStream(STDOUT, $this->getLoop());
+
+        $this->inputStream->on('data', fn ($data) => $this->handleStream($data));
+
+        return $this;
+    }
+
+    /**
+     * Handle the input stream.
+     */
+    public function handleStream(string $data): void
+    {
+        $command = trim($data);
+
+        if (! $command) {
+            $this->outputStream->write('> ');
+
+            return;
+        }
+
+        $this->console()->newLine();
+
+        match ($command) {
+            'shutdown', 'exit', 'quit', 'stop' => $this->shutdown(),
+            'restart' => $this->restart(),
+            'invite' => $this->showInvite(force: true),
+            'commands' => $this->showCommands(),
+            '?' => table([
+                ['<fg=blue>Command</>', '<fg=blue>Description</>'],
+                ['shutdown', 'Shutdown the bot'],
+                ['restart', 'Restart the bot'],
+                ['invite', 'Show the invite link'],
+                ['commands', 'Show the registered commands'],
+            ]),
+            default => $this->console()->error("Unknown command: <fg=red>{$command}</>"),
+        };
+
+        $this->outputStream->write('> ');
+    }
+
+    /**
+     * Shutdown the bot.
+     */
+    public function shutdown(int $code = 0): void
+    {
+        $this->console()->log("Shutting down <fg=blue>{$this->getName()}</>.");
+
+        $this->httpServer()->shutdown();
+        $this->discord()->close();
+
+        exit($code);
+    }
+
+    /**
+     * Restart the bot.
+     */
+    public function restart(): void
+    {
+        $this->console()->log("<fg=blue>{$this->getName()}</> is restarting.");
+
+        $this->httpServer()->shutdown();
+        $this->discord()->close();
+
+        $this->httpServer = null;
+        $this->discord = null;
+
+        $this->registeredCommands = [];
+        $this->registeredEvents = [];
+        $this->registeredServices = [];
+
+        $this->boot();
     }
 
     /**
@@ -543,13 +647,15 @@ class Laracord
     /**
      * Show the invite link if the bot is not in any guilds.
      */
-    public function showInvite(): self
+    public function showInvite(bool $force = false): self
     {
-        if (! $this->showInvite || $this->discord()->guilds->count() > 0) {
+        if (! $force && (! $this->showInvite || $this->discord()->guilds->count() > 0)) {
             return $this;
         }
 
-        $this->console()->warn("{$this->getName()} is currently not in any guilds.");
+        if (! $force) {
+            $this->console()->warn("{$this->getName()} is currently not in any guilds.");
+        }
 
         $query = Arr::query([
             'client_id' => $this->discord()->id,
@@ -794,34 +900,6 @@ class Laracord
     }
 
     /**
-     * Get the event loop.
-     */
-    public function getLoop()
-    {
-        if ($this->loop) {
-            return $this->loop;
-        }
-
-        return $this->loop = Loop::get();
-    }
-
-    /**
-     * Get the Discord instance.
-     */
-    public function discord(): Discord
-    {
-        return $this->discord;
-    }
-
-    /**
-     * Get the console instance.
-     */
-    public function console(): ConsoleCommand
-    {
-        return $this->console;
-    }
-
-    /**
      * Retrieve the prefixes.
      */
     public function getPrefixes(): Collection
@@ -847,6 +925,42 @@ class Laracord
     public function getPrefix(): string
     {
         return $this->getPrefixes()->first();
+    }
+
+    /**
+     * Get the event loop.
+     */
+    public function getLoop()
+    {
+        if ($this->loop) {
+            return $this->loop;
+        }
+
+        return $this->loop = Loop::get();
+    }
+
+    /**
+     * Get the Discord instance.
+     */
+    public function discord(): ?Discord
+    {
+        return $this->discord;
+    }
+
+    /**
+     * Get the console instance.
+     */
+    public function console(): ConsoleCommand
+    {
+        return $this->console;
+    }
+
+    /**
+     * Get the HTTP server instance.
+     */
+    public function httpServer(): ?Server
+    {
+        return $this->httpServer;
     }
 
     /**

--- a/src/Laracord.php
+++ b/src/Laracord.php
@@ -267,10 +267,10 @@ class Laracord
             'invite' => $this->showInvite(force: true),
             'commands' => $this->showCommands(),
             '?' => table(['<fg=blue>Command</>', '<fg=blue>Description</>'], [
-                ['shutdown', 'Shutdown the bot'],
-                ['restart', 'Restart the bot'],
-                ['invite', 'Show the invite link'],
-                ['commands', 'Show the registered commands'],
+                ['shutdown', 'Shutdown the bot.'],
+                ['restart', 'Restart the bot.'],
+                ['invite', 'Show the invite link.'],
+                ['commands', 'Show the registered commands.'],
             ]),
             default => $this->console()->error("Unknown command: <fg=red>{$command}</>"),
         };

--- a/src/Laracord.php
+++ b/src/Laracord.php
@@ -266,8 +266,7 @@ class Laracord
             'restart' => $this->restart(),
             'invite' => $this->showInvite(force: true),
             'commands' => $this->showCommands(),
-            '?' => table([
-                ['<fg=blue>Command</>', '<fg=blue>Description</>'],
+            '?' => table(['<fg=blue>Command</>', '<fg=blue>Description</>'], [
                 ['shutdown', 'Shutdown the bot'],
                 ['restart', 'Restart the bot'],
                 ['invite', 'Show the invite link'],


### PR DESCRIPTION
This adds basic support for input stream commands to stop, restart, and invite the bot.

![Screenshot](https://i.imgur.com/WaOlr22.png)

## Change log

### Enhancements

- ✨ Add input/output stream support (Fixes #41) 
- ✨ Add generic input stream commands `stop`, `restart`, `invite`, `commands`, and `?`
- ✨ Add file support to the Message component 
- 🧑‍💻 Create methods to shutdown and restart Laracord
- 🧑‍💻 Add support for forcefully displaying the invite link
- 🧑‍💻 Add registered route count to the boot status
- 🧑‍💻 Add a `httpServer()` getter method
- 🎨 Minor code improvements
- 🧑‍💻 Add a shutdown() method to the HTTP server 
- 🎨 Add missing `bot` properties
- 🎨 Improve usage of the `bot` property

### Bug fixes

- 🩹 Fix typo in `httpServer` property return type