### PR TITLE
✨ Add default permission support & option parsing to slash commands

### DIFF
--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -157,11 +157,11 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
      */
     protected function option($key = null, $default = null)
     {
-        if (is_null($key) || ! $this->getParsedOptions()) {
-            return $this->getParsedOptions();
+        if (is_null($key) || ! $this->getOptions()) {
+            return $this->getOptions();
         }
 
-        return Arr::get($this->getParsedOptions(), $key, $default);
+        return Arr::get($this->getOptions(), $key, $default);
     }
 
     /**

--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -5,6 +5,9 @@ namespace Laracord\Commands;
 use Discord\Builders\CommandBuilder;
 use Discord\Parts\Interactions\Command\Command as DiscordCommand;
 use Discord\Parts\Interactions\Command\Option as DiscordOption;
+use Discord\Parts\Interactions\Interaction;
+use Discord\Parts\Permissions\RolePermission;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Laracord\Commands\Contracts\SlashCommand as SlashCommandContract;
 
@@ -16,6 +19,13 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
      * @var string
      */
     protected $guild;
+
+    /**
+     * The default required permission for the command.
+     *
+     * @var string
+     */
+    protected $permission;
 
     /**
      * The command options.
@@ -32,6 +42,13 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
     protected $registeredOptions = [];
 
     /**
+     * The parsed command options.
+     *
+     * @var array
+     */
+    protected $parsedOptions = [];
+
+    /**
      * Create a Discord command instance.
      */
     public function create(): DiscordCommand
@@ -40,8 +57,12 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
             ->setName($this->getName())
             ->setDescription($this->getDescription());
 
-        if ($this->getOptions()) {
-            foreach ($this->getOptions() as $option) {
+        if ($permission = $this->getPermission()) {
+            $command = $command->setDefaultPermission($permission);
+        }
+
+        if ($this->getRegisteredOptions()) {
+            foreach ($this->getRegisteredOptions() as $option) {
                 $command = $command->addOption($option);
             }
         }
@@ -71,7 +92,11 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
     public function maybeHandle($interaction)
     {
         if (! $this->isAdminCommand()) {
+            $this->parseOptions($interaction);
+
             $this->handle($interaction);
+
+            $this->clearOptions();
 
             return;
         }
@@ -84,11 +109,59 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
                     ->message('You do not have permission to run this command.')
                     ->title('Permission Denied')
                     ->error()
-                    ->build()
+                    ->build(),
+                ephemeral: true
             );
         }
 
+        $this->parseOptions($interaction);
+
         $this->handle($interaction);
+
+        $this->clearOptions();
+    }
+
+    /**
+     * Parse the options inside of the interaction.
+     *
+     * We serialize the options and then decode them back to an array
+     * to get rid of excess data.
+     */
+    protected function parseOptions(Interaction $interaction): void
+    {
+        $this->parsedOptions = json_decode($interaction->data->options->serialize(), true);
+    }
+
+    /**
+     * Get the parsed options.
+     */
+    protected function getOptions(): array
+    {
+        return $this->parsedOptions ?? [];
+    }
+
+    /**
+     * Clear the parsed options.
+     */
+    protected function clearOptions(): void
+    {
+        $this->parsedOptions = [];
+    }
+
+    /**
+     * Retrieve the parsed command options.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    protected function option($key = null, $default = null)
+    {
+        if (is_null($key) || ! $this->getParsedOptions()) {
+            return $this->getParsedOptions();
+        }
+
+        return Arr::get($this->getParsedOptions(), $key, $default);
     }
 
     /**
@@ -113,12 +186,22 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
 
     /**
      * Retrieve the slash command guild.
-     *
-     * @return string
      */
-    public function getGuild()
+    public function getGuild(): ?string
     {
-        return $this->guild;
+        return $this->guild ?? null;
+    }
+
+    /**
+     * Retrieve the slash command bitwise permission.
+     */
+    public function getPermission(): ?string
+    {
+        if (! $this->permission) {
+            return null;
+        }
+
+        return (new RolePermission($this->discord(), [$this->permission => true]))->__toString();
     }
 
     /**
@@ -126,7 +209,7 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
      *
      * @return array
      */
-    public function getOptions()
+    public function getRegisteredOptions()
     {
         if ($this->registeredOptions) {
             return $this->registeredOptions;

--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -21,11 +21,11 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
     protected $guild;
 
     /**
-     * The default required permission for the command.
+     * The permissions required to use the command.
      *
-     * @var string
+     * @var array
      */
-    protected $permission;
+    protected $permissions = [];
 
     /**
      * The command options.
@@ -57,8 +57,8 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
             ->setName($this->getName())
             ->setDescription($this->getDescription());
 
-        if ($permission = $this->getPermission()) {
-            $command = $command->setDefaultPermission($permission);
+        if ($permissions = $this->getPermissions()) {
+            $command = $command->setDefaultMemberPermissions($permissions);
         }
 
         if ($this->getRegisteredOptions()) {
@@ -195,13 +195,17 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
     /**
      * Retrieve the slash command bitwise permission.
      */
-    public function getPermission(): ?string
+    public function getPermissions(): ?string
     {
-        if (! $this->permission) {
+        if (! $this->permissions) {
             return null;
         }
 
-        return (new RolePermission($this->discord(), [$this->permission => true]))->__toString();
+        $permissions = collect($this->permissions)
+            ->mapWithKeys(fn ($permission) => [$permission => true])
+            ->all();
+
+        return (new RolePermission($this->discord(), $permissions))->__toString();
     }
 
     /**

--- a/src/Console/Commands/stubs/slash-command.stub
+++ b/src/Console/Commands/stubs/slash-command.stub
@@ -7,14 +7,14 @@ use Laracord\Commands\SlashCommand;
 class {{ class }} extends SlashCommand
 {
     /**
-     * The slash command name.
+     * The command name.
      *
      * @var string
      */
     protected $name = '{{ command }}';
 
     /**
-     * The slash command description.
+     * The command description.
      *
      * @var string
      */
@@ -28,14 +28,21 @@ class {{ class }} extends SlashCommand
     protected $options = [];
 
     /**
-     * Indiciates whether the slash command requires admin permissions.
+     * The permissions required to use the command.
+     *
+     * @var array
+     */
+    protected $permissions = [];
+
+    /**
+     * Indiciates whether the command requires admin permissions.
      *
      * @var bool
      */
     protected $admin = false;
 
     /**
-     * Indicates whether the slash command should be displayed in the commands list.
+     * Indicates whether the command should be displayed in the commands list.
      *
      * @var bool
      */

--- a/src/Discord/Message.php
+++ b/src/Discord/Message.php
@@ -9,6 +9,7 @@ use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message as ChannelMessage;
 use Discord\Parts\User\User;
 use Exception;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laracord\Laracord;
 use React\Promise\ExtendedPromiseInterface;
@@ -515,8 +516,16 @@ class Message
     /**
      * Set the message timestamp.
      */
-    public function timestamp(?string $timestamp): self
+    public function timestamp(mixed $timestamp = null): self
     {
+        if (! $timestamp) {
+            $timestamp = now();
+        }
+
+        if ($timestamp instanceof Carbon) {
+            $timestamp = $timestamp->toIso8601String();
+        }
+
         $this->timestamp = $timestamp;
 
         return $this;

--- a/src/Discord/Message.php
+++ b/src/Discord/Message.php
@@ -595,6 +595,16 @@ class Message
     }
 
     /**
+     * Clear the fields from the message.
+     */
+    public function clearFields(): self
+    {
+        $this->fields = [];
+
+        return $this;
+    }
+
+    /**
      * Set the message components.
      */
     public function components(array $components): self
@@ -660,6 +670,16 @@ class Message
 
             $this->button(...$value);
         }
+
+        return $this;
+    }
+
+    /**
+     * Clear the buttons from the message.
+     */
+    public function clearButtons(): self
+    {
+        $this->buttons = [];
 
         return $this;
     }


### PR DESCRIPTION
## Change log

### Enhancements

- ✨ Add default permission support to slash commands 
- ✨ Add option parsing to slash commands
- 🧑‍💻 Add `clearFields()` and `clearButtons()` to the Message builder
- 🧑‍💻 Add carbon support to `timestamp()`
- 🧑‍💻 Default to current time when nothing is passed to `timestamp()`