### PR TITLE
🧑‍💻 Allow passing disabled to message buttons 

### DIFF
--- a/src/Discord/Message.php
+++ b/src/Discord/Message.php
@@ -646,10 +646,10 @@ class Message
 
         if ($options) {
             foreach ($options as $key => $option) {
-                $key = Str::of($key)->camel()->ucfirst()->toString();
+                $key = Str::of($key)->camel()->ucfirst()->start('set')->toString();
 
                 try {
-                    $button = $button->set{$key}($option);
+                    $button = $button->{$key}($option);
                 } catch (Throwable) {
                     $this->bot->console()->error("Invalid button option <fg=red>{$key}</>");
 

--- a/src/Discord/Message.php
+++ b/src/Discord/Message.php
@@ -626,7 +626,7 @@ class Message
     /**
      * Add a URL button to the message.
      */
-    public function button(string $label, mixed $value, mixed $emoji = null, ?string $style = null, array $options = []): self
+    public function button(string $label, mixed $value, mixed $emoji = null, ?string $style = null, bool $disabled = false, array $options = []): self
     {
         $style = match ($style) {
             'link' => Button::STYLE_LINK,
@@ -641,14 +641,15 @@ class Message
 
         $button = Button::new($style)
             ->setLabel($label)
-            ->setEmoji($emoji);
+            ->setEmoji($emoji)
+            ->setDisabled($disabled);
 
         if ($options) {
             foreach ($options as $key => $option) {
-                $key = Str::of($key)->camel()->ucfirst()->__toString();
+                $key = Str::of($key)->camel()->ucfirst()->toString();
 
                 try {
-                    $button = $button->{$key}($option);
+                    $button = $button->set{$key}($option);
                 } catch (Throwable) {
                     $this->bot->console()->error("Invalid button option <fg=red>{$key}</>");
 

--- a/src/Laracord.php
+++ b/src/Laracord.php
@@ -882,6 +882,15 @@ class Laracord
     }
 
     /**
+     * Get a registered command by name.
+     */
+    public function getCommand(string $name): Command|SlashCommand|null
+    {
+        return collect($this->registeredCommands)
+            ->first(fn ($command) => $command->getName() === $name);
+    }
+
+    /**
      * Get the path to the Discord commands.
      */
     public function getCommandPath(): string


### PR DESCRIPTION
## Change log

### Enhancements

- 🧑‍💻 Allow passing `disabled` to message buttons 
- 🧑‍💻 Prepend `set` to the button option keys
- 🧑‍💻 Add a `getCommand()` method to easily obtain a command instance