### PR TITLE
Add method to fetch option 'value' key from command options

### DIFF
--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -133,19 +133,6 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
     }
 
     /**
-     * Retrieve the 'value' field from the parsed command option for a given key.
-     * This function specifically accesses the 'value' key within the option array.
-     *
-     * @param $key
-     * @param $default
-     * @return mixed|null
-     */
-    protected function getOptionValue(string $key = null, $default = null)
-    {
-        return $this->option($key, $default)['value'] ?? $default;
-    }
-    
-    /**
      * Get the parsed options.
      */
     protected function getOptions(): array
@@ -163,12 +150,8 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
 
     /**
      * Retrieve the parsed command options.
-     *
-     * @param  string|null  $key
-     * @param  mixed  $default
-     * @return mixed
      */
-    protected function option($key = null, $default = null)
+    protected function option(?string $key = null, mixed $default = null): mixed
     {
         if (is_null($key) || ! $this->getOptions()) {
             return $this->getOptions();
@@ -178,11 +161,23 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
     }
 
     /**
-     * Set the command options.
-     *
-     * @return array
+     * Retrieve the option value.
      */
-    public function options()
+    public function value(?string $option = null, mixed $default = null): mixed
+    {
+        $options = $this->flattenOptions($this->getOptions());
+
+        if (is_null($option)) {
+            return $options;
+        }
+
+        return $options[$option] ?? $default;
+    }
+
+    /**
+     * Set the command options.
+     */
+    public function options(): array
     {
         return [];
     }
@@ -223,10 +218,8 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
 
     /**
      * Retrieve the slash command options.
-     *
-     * @return array
      */
-    public function getRegisteredOptions()
+    public function getRegisteredOptions(): ?array
     {
         if ($this->registeredOptions) {
             return $this->registeredOptions;
@@ -242,5 +235,32 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
             ? $option
             : new DiscordOption($this->discord(), $option)
         )->map(fn ($option) => $option->setName(Str::slug($option->name)))->all();
+    }
+
+    /**
+     * Flatten the options into dot notated keys.
+     */
+    protected function flattenOptions(array $options, ?string $parent = null): array
+    {
+        return collect($options)->flatMap(function ($option) use ($parent) {
+            $key = $parent ? "{$parent}.{$option['name']}" : $option['name'];
+
+            if (is_array($option) && isset($option['options'])) {
+                $options = $this->flattenOptions($option['options'], $key);
+
+                if (array_key_exists('value', $option)) {
+                    return [
+                        ...[$key => $option['value']],
+                        ...$options,
+                    ];
+                }
+
+                return $options;
+            }
+
+            return isset($option['value'])
+                ? [$key => $option['value']]
+                : [];
+        })->all();
     }
 }

--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -133,6 +133,19 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
     }
 
     /**
+     * Retrieve the 'value' field from the parsed command option for a given key.
+     * This function specifically accesses the 'value' key within the option array.
+     *
+     * @param $key
+     * @param $default
+     * @return mixed|null
+     */
+    protected function getOptionValue(string $key = null, $default = null)
+    {
+        return $this->option($key, $default)['value'] ?? $default;
+    }
+    
+    /**
      * Get the parsed options.
      */
     protected function getOptions(): array


### PR DESCRIPTION
This commit introduces a new method, `getOptionValue`, in our command handling class. The method simplifies retrieving the 'value' key directly from the command options. It helps avoid repetitive array access code and makes our option parsing cleaner. The method assumes options are stored as arrays with a 'value' key and handles the absence of such a key gracefully by returning a default value if specified or null otherwise.