### PR TITLE
✨ Add webhook support to Messages (Fixes #52)

### DIFF
--- a/src/Discord/Message.php
+++ b/src/Discord/Message.php
@@ -310,7 +310,7 @@ class Message
 
         return $this;
     }
-  
+
     /**
      * Reply to a message or interaction.
      */

--- a/src/Discord/Message.php
+++ b/src/Discord/Message.php
@@ -591,6 +591,16 @@ class Message
     /**
      * Set the message thumbnail URL.
      */
+    public function thumbnail(?string $thumbnailUrl): self
+    {
+        $this->thumbnailUrl = $thumbnailUrl;
+
+        return $this;
+    }
+
+    /**
+     * Set the message thumbnail URL.
+     */
     public function thumbnailUrl(?string $thumbnailUrl): self
     {
         $this->thumbnailUrl = $thumbnailUrl;
@@ -604,6 +614,16 @@ class Message
     public function url(?string $url): self
     {
         $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * Set the message image URL.
+     */
+    public function image(?string $imageUrl): self
+    {
+        $this->imageUrl = $imageUrl;
 
         return $this;
     }

--- a/src/Discord/Message.php
+++ b/src/Discord/Message.php
@@ -7,13 +7,18 @@ use Discord\Builders\Components\Button;
 use Discord\Builders\MessageBuilder;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message as ChannelMessage;
+use Discord\Parts\Channel\Webhook;
 use Discord\Parts\User\User;
+use Discord\Repository\Channel\WebhookRepository;
 use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laracord\Laracord;
 use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 use Throwable;
+
+use function React\Async\await;
 
 class Message
 {
@@ -128,6 +133,11 @@ class Message
     protected array $files = [];
 
     /**
+     * The message webhook.
+     */
+    protected string|bool $webhook = false;
+
+    /**
      * The default embed colors.
      */
     protected array $colors = [
@@ -148,8 +158,10 @@ class Message
         $this->bot = $bot ?: app('bot');
 
         $this
-            ->authorName($this->bot->discord()->user->username)
-            ->authorIcon($this->bot->discord()->user->avatar)
+            ->username($username = $this->bot->discord()->username)
+            ->avatar($avatar = $this->bot->discord()->avatar)
+            ->authorName($username)
+            ->authorIcon($avatar)
             ->success();
     }
 
@@ -167,6 +179,8 @@ class Message
     public function build(): MessageBuilder
     {
         $message = MessageBuilder::new()
+            ->setUsername($this->username)
+            ->setAvatarUrl($this->avatarUrl)
             ->setTts($this->tts)
             ->setContent($this->body)
             ->setComponents($this->getComponents());
@@ -191,10 +205,52 @@ class Message
     /**
      * Send the message.
      */
-    public function send(mixed $destination = null): ?ExtendedPromiseInterface
+    public function send(mixed $destination = null): PromiseInterface|ExtendedPromiseInterface|null
     {
         if ($destination) {
             $this->channel($destination);
+        }
+
+        if ($this->webhook) {
+            try {
+                /** @var WebhookRepository $webhooks */
+                $webhooks = await($this->getChannel()->webhooks->freshen());
+            } catch (Exception) {
+                $this->bot->console()->error("\nUnable to fetch channel webhooks. Does the bot have permission?");
+
+                return null;
+            }
+
+            if (! $webhooks) {
+                $this->bot->console()->error('Failed to fetch channel webhooks.');
+
+                return null;
+            }
+
+            if ($this->webhook === true) {
+                $webhook = $webhooks->find(fn (Webhook $webhook) => $webhook->name === $this->bot->discord()->username);
+
+                if (! $webhook) {
+                    return $webhooks->save(new Webhook($this->bot->discord(), [
+                        'name' => $this->bot->discord()->username,
+                    ]))->then(
+                        fn (Webhook $webhook) => $webhook->execute($this->build()),
+                        fn () => $this->bot->console()->error('Failed to create message webhook.')
+                    );
+                }
+
+                return $webhook->execute($this->build());
+            }
+
+            $webhook = $this->getChannel()->webhooks->get('url', $this->webhook);
+
+            if (! $webhook) {
+                $this->bot->console()->error("Could not find webhook <fg=red>{$this->webhook}</> on channel to send message.");
+
+                return null;
+            }
+
+            return $webhook->execute($this->build());
         }
 
         return $this->getChannel()->sendMessage($this->build());
@@ -228,6 +284,16 @@ class Message
         }
 
         return $user->sendMessage($this->build());
+    }
+
+    /**
+     * Send the message as a webhook.
+     */
+    public function webhook(string|bool $value = true): self
+    {
+        $this->webhook = $value;
+
+        return $this;
     }
 
     /**
@@ -338,6 +404,14 @@ class Message
         $this->content = $content;
 
         return $this;
+    }
+
+    /**
+     * Set the message avatar.
+     */
+    public function avatar(?string $avatarUrl): self
+    {
+        return $this->avatarUrl($avatarUrl);
     }
 
     /**
@@ -559,6 +633,14 @@ class Message
         $this->authorIcon = $authorIcon;
 
         return $this;
+    }
+
+    /**
+     * Clear the message author.
+     */
+    public function clearAuthor(): self
+    {
+        return $this->authorName('')->authorIcon('');
     }
 
     /**


### PR DESCRIPTION
This adds a `->webhook()` method that will send messages in a channel through a webhook to allow for further customization such as username & avatar.

It can be used in two ways:

When passing no argument, Laracord will attempt to create a webhook in the destination channel with the same name as the bot. It will then re-use that webhook when sending webhook messages in that channel in the future:

```php
$this
    ->message()
    ->username('Example')
    ->avatar('https://example.com/avatar.png')
    ->content('Hello world!')
    ->webhook()
    ->send($channel);
```

The second way would be to pass a webhook URL of which already exists for the destination channel:

```php
$this
    ->message()
    ->username('Example')
    ->avatar('https://example.com/avatar.png')
    ->content('Hello world!')
    ->webhook('https://discord.com/api/webhooks/...')
    ->send($channel);
```

This will attempt to retrieve the `Webhook` part from DiscordPHP's `WebhookRepository` using the URL and then send the message using the webhook.

A future improvement might be to allow sending directly to any webhook URL instead of using DiscordPHP (or the bot).

## Change log

### Enhancements

- ✨ Add webhook support to Messages (Fixes #52)
- 🧑‍💻 Add a `clearAuthor()` method to clear the default Message embed author/icon 
- 🧑‍💻 Add an `avatar()` method that aliases `avatarUrl()` for improved DX