### PR TITLE
✨ Add persistent interaction routing support to commands (Fixes #79)

### DIFF
--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -99,6 +99,14 @@ abstract class AbstractCommand
     }
 
     /**
+     * The command interaction routes.
+     */
+    public function interactions(): array
+    {
+        return [];
+    }
+
+    /**
      * Build an embed for use in a Discord message.
      *
      * @param  string  $content
@@ -106,7 +114,7 @@ abstract class AbstractCommand
      */
     public function message($content = '')
     {
-        return $this->bot()->message($content);
+        return $this->bot()->message($content)->routePrefix($this->getName());
     }
 
     /**

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -3,7 +3,6 @@
 namespace Laracord\Commands;
 
 use Laracord\Commands\Contracts\Command as CommandContract;
-use Laracord\Discord\Message;
 
 abstract class Command extends AbstractCommand implements CommandContract
 {

--- a/src/Console/Commands/stubs/command.stub
+++ b/src/Console/Commands/stubs/command.stub
@@ -2,6 +2,7 @@
 
 namespace {{ namespace }};
 
+use Discord\Parts\Interactions\Interaction;
 use Laracord\Commands\Command;
 
 class {{ class }} extends Command
@@ -47,6 +48,17 @@ class {{ class }} extends Command
             ->message()
             ->title('{{ class }}')
             ->content('Hello world!')
+            ->button('👋', route: 'wave')
             ->send($message);
+    }
+
+    /**
+     * The command interaction routes.
+     */
+    public function interactions(): array
+    {
+        return [
+            'wave' => fn (Interaction $interaction) => $this->message('👋')->reply($interaction), 
+        ];
     }
 }

--- a/src/Console/Commands/stubs/slash-command.stub
+++ b/src/Console/Commands/stubs/slash-command.stub
@@ -2,6 +2,7 @@
 
 namespace {{ namespace }};
 
+use Discord\Parts\Interactions\Interaction;
 use Laracord\Commands\SlashCommand;
 
 class {{ class }} extends SlashCommand
@@ -61,7 +62,18 @@ class {{ class }} extends SlashCommand
               ->message()
               ->title('{{ class }}')
               ->content('Hello world!')
+              ->button('👋', route: 'wave')
               ->build()
         );
+    }
+
+    /**
+     * The command interaction routes.
+     */
+    public function interactions(): array
+    {
+        return [
+            'wave' => fn (Interaction $interaction) => $this->message('👋')->reply($interaction), 
+        ];
     }
 }


### PR DESCRIPTION
This PR adds persistent interaction routing allowing for easy persistence and handling of interactions such as button clicks.

It is based on Laravel routing and allows for passing parameters such as `{id}` and making them optional using a `?` like `{id?}`. All parameters should be passed using `:` instead of `/`. 

All routes are prefixed with the command name behind the scenes to remain unique.

It is hopefully pretty straight forward to use, see the following example:

```php
/**
 * Handle the command.
 */
public function handle($message, $args)
{
    return $this
        ->message()
        ->title('Hello')
        ->content('Hello world!')
        ->button('👋', route: 'wave')
        ->button('Test', route: 'wave:12345')
        ->send($message);
}

/**
 * The command interaction routes.
 */
public function interactions(): array
{
    return [
        'wave' => fn (Interaction $interaction) => $this->message('👋')->reply($interaction, true),
        'wave:{id?}' => fn (Interaction $interaction, string $id = 'default') => $this->message("Hello from {$id}")->reply($interaction, true),
    ];
}
```