### PR TITLE
✨ Allow restricting a chat command to a specific guild (Fixes #70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Build functional, elegant bots harnessing the full power of [Laravel](https://la
 - ⚡️ Out of the box support for databases, caching, and many other Laravel features thanks to [Laravel Zero](https://laravel-zero.com/).
 - 🚀 Instantly generate working bot [commands](https://laracord.com/docs/commands) and [event listeners](https://laracord.com/docs/events) with 0 knowledge.
 - 🧑‍💻 Automatic handling of registering/updating/unregistering application [slash commands](https://laracord.com/docs/slash-commands).
+- 🚚 Easy to use [interaction routing](https://laracord.com/docs/interactions) for persistence on message buttons and actions.
 - 👷 Generate asynchronous [services/tasks](https://laracord.com/docs/services) that run parallel to the bot.
 - 🌎 Optional [HTTP Server](https://laracord.com/docs/http-server) with native Laravel routing and [Livewire support](https://laracord.com/docs/livewire).
 - 🔧 Fully configurable and extendable.

--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -2,6 +2,7 @@
 
 namespace Laracord\Commands;
 
+use Discord\Parts\Guild\Guild;
 use Discord\Parts\User\User;
 use Illuminate\Support\Str;
 use Laracord\Laracord;
@@ -56,6 +57,13 @@ abstract class AbstractCommand
      * @var string|null
      */
     protected $description;
+
+    /**
+     * The guild the command belongs to.
+     *
+     * @var string
+     */
+    protected $guild;
 
     /**
      * Determines whether the command requires admin permissions.
@@ -225,6 +233,14 @@ abstract class AbstractCommand
     public function getDescription()
     {
         return $this->description;
+    }
+
+    /**
+     * Retrieve the command guild.
+     */
+    public function getGuild(): ?string
+    {
+        return $this->guild ?? null;
     }
 
     /**

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -43,13 +43,17 @@ abstract class Command extends AbstractCommand implements CommandContract
      */
     public function maybeHandle($message, $args)
     {
+        if ($this->getGuild() && $message->guild_id !== $this->getGuild()) {
+            return;
+        }
+
+        $this->server = $message->channel->guild;
+
         if (! $this->isAdminCommand()) {
             $this->handle($message, $args);
 
             return;
         }
-
-        $this->server = $message->channel->guild;
 
         if ($this->isAdminCommand() && ! $this->isAdmin($message->author)) {
             return;

--- a/src/Commands/HelpCommand.php
+++ b/src/Commands/HelpCommand.php
@@ -48,7 +48,10 @@ class HelpCommand extends Command
      */
     public function handle($message, $args)
     {
-        $commands = collect($this->bot()->getRegisteredCommands())->filter(fn ($command) => ! $command->isHidden());
+        $commands = collect($this->bot()->getRegisteredCommands())
+            ->filter(fn ($command) => ! $command->isHidden())
+            ->filter(fn ($command) => $command->getGuild() ? $message->guild_id === $command->getGuild() : true)
+            ->sortBy('name');
 
         $fields = [];
 

--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -14,13 +14,6 @@ use Laracord\Commands\Contracts\SlashCommand as SlashCommandContract;
 abstract class SlashCommand extends AbstractCommand implements SlashCommandContract
 {
     /**
-     * The guild the command belongs to.
-     *
-     * @var string
-     */
-    protected $guild;
-
-    /**
      * The permissions required to use the command.
      *
      * @var array
@@ -91,6 +84,8 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
      */
     public function maybeHandle($interaction)
     {
+        $this->server = $interaction->guild;
+
         if (! $this->isAdminCommand()) {
             $this->parseOptions($interaction);
 
@@ -100,8 +95,6 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
 
             return;
         }
-
-        $this->server = $interaction->guild;
 
         if ($this->isAdminCommand() && ! $this->isAdmin($interaction->member->user)) {
             return $interaction->respondWithMessage(
@@ -190,14 +183,6 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
     public function getSignature()
     {
         return Str::start($this->getName(), '/');
-    }
-
-    /**
-     * Retrieve the slash command guild.
-     */
-    public function getGuild(): ?string
-    {
-        return $this->guild ?? null;
     }
 
     /**

--- a/src/Discord/Message.php
+++ b/src/Discord/Message.php
@@ -528,10 +528,12 @@ class Message
         };
 
         if (str_starts_with($color, '#')) {
-            $color = hexdec(substr($color, 1));
+            $color = hexdec(
+                Str::of($color)->replace('#', '')->limit(6, '')->toString()
+            );
         }
 
-        $this->color = $color;
+        $this->color = (string) $color;
 
         return $this;
     }

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -146,7 +146,7 @@ abstract class Event
         }
 
         $classes = collect(File::allFiles($source))
-            ->mapWithKeys(fn ($file) => [Str::of($file->getFilename())->replace('.php', '')->__toString() => $file->getPathname()]);
+            ->mapWithKeys(fn ($file) => [Str::of($file->getFilename())->replace('.php', '')->toString() => $file->getPathname()]);
 
         return collect($events)->mapWithKeys(function ($path, $event) use ($classes) {
             $class = Str::of($event)
@@ -154,13 +154,17 @@ abstract class Event
                 ->replace('_', ' ')
                 ->headline()
                 ->replace(' ', '')
-                ->__toString();
+                ->toString();
 
             if (! $classes->has($class)) {
                 return [];
             }
 
-            $name = Str::of($event)->lower()->replace('_', ' ')->headline()->__toString();
+            $name = Str::of($event)
+                ->lower()
+                ->replace('_', ' ')
+                ->headline()
+                ->toString();
 
             return [$event => [
                 'key' => $event,


### PR DESCRIPTION
## Change log

### Enhancements

- ✨ Allow restricting a chat command to a specific guild (Fixes #70)
- 🔒 Filter guild-specific commands when using `!help `
- 🎨 Sort the `!help` commands by name
- 🎨 Clean up `Str::toString()` usage
- 🎨 Ensure that `Message::$color` is set as a string
- ✨ Add a `status` command to the bot stdin 
- 🎨 Add missing type on the `loop` property
- 🧑‍💻 Abstract the logger into a method to make it easier to override
- 📝 Update the features list