### PR TITLE
✨ Add async macros to common Facade methods

### DIFF
--- a/src/Concerns/CanAsync.php
+++ b/src/Concerns/CanAsync.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Laracord\Concerns;
+
+use Exception;
+use React\Promise\Promise;
+
+trait CanAsync
+{
+    /**
+     * Perform an asynchronous operation.
+     */
+    public static function handleAsync(callable $callback): Promise
+    {
+        return new Promise(function ($resolve, $reject) use ($callback) {
+            if (! $loop = app('bot')?->getLoop()) {
+                throw new Exception('The Laracord event loop is not available.');
+            }
+
+            $loop->futureTick(function () use ($callback, $resolve, $reject) {
+                try {
+                    $result = $callback();
+                    $resolve($result);
+                } catch (Exception $e) {
+                    $reject($e);
+                }
+            });
+        });
+    }
+
+    /**
+     * Perform an asynchronous operation.
+     */
+    public function async(callable $callback): Promise
+    {
+        return static::async($callback);
+    }
+}

--- a/src/Laracord.php
+++ b/src/Laracord.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Laracord\Commands\Command;
 use Laracord\Commands\SlashCommand;
+use Laracord\Concerns\CanAsync;
 use Laracord\Console\Commands\Command as ConsoleCommand;
 use Laracord\Discord\Message;
 use Laracord\Events\Event;
@@ -35,6 +36,8 @@ use function React\Promise\all;
 
 class Laracord
 {
+    use CanAsync;
+
     /**
      * The event loop.
      */

--- a/src/LaracordServiceProvider.php
+++ b/src/LaracordServiceProvider.php
@@ -4,6 +4,7 @@ namespace Laracord;
 
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
@@ -140,6 +141,9 @@ class LaracordServiceProvider extends ServiceProvider
 
         Http::macro('getAsync', fn (string $url, array|string|null $query = []) => Laracord::handleAsync(fn () => Http::get($url, $query)));
         Http::macro('postAsync', fn (string $url, array $data = []) => Laracord::handleAsync(fn () => Http::post($url, $data = [])));
+
+        File::macro('getAsync', fn (string $path) => Laracord::handleAsync(fn () => File::get($path)));
+        File::macro('putAsync', fn (string $path, mixed $contents) => Laracord::handleAsync(fn () => File::put($path, $contents)));
 
         Storage::macro('getAsync', fn (string $path) => Laracord::handleAsync(fn () => Storage::get($path)));
         Storage::macro('putAsync', fn (string $path, mixed $contents) => Laracord::handleAsync(fn () => Storage::put($path, $contents)));


### PR DESCRIPTION
This adds async macros to common methods inside of `Cache`, `Http` and `Storage` facades.

```php
Cache::getAsync(string $key);
Cache::putAsync(string $key, mixed $value, int $seconds);
Cache::rememberAsync(string $key, int $seconds, callable $callback);
Cache::rememberForeverAsync(string $key, callable $callback);

Http::getAsync(string $url, array|string|null $query = []);
Http::postAsync(string $url, array $data = []);

File::getAsync(string $path);
File::putAsync(string $path, mixed $contents);

Storage::getAsync(string $path);
Storage::putAsync(string $path, mixed $contents);
```

## Change log

### Enhancements

- ✨ Add async macros for common methods to the `Cache`, `Http` and `Storage` facades
- ✨ Create an `CanAsync` trait to easily perform async tasks in the event loop