### PR TITLE
✨Native option autocomplete support 

### DIFF
--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -41,13 +41,6 @@ abstract class AbstractCommand
     protected $user;
 
     /**
-     * The server instance.
-     *
-     * @var \Discord\Parts\Guild\Guild
-     */
-    protected $server;
-
-    /**
      * The command name.
      *
      * @var string
@@ -149,16 +142,13 @@ abstract class AbstractCommand
 
     /**
      * Resolve a Discord user.
-     *
-     * @param  string  $username
-     * @return \Discord\Parts\User\User|null
      */
-    public function resolveUser($username = null)
+    public function resolveUser(string $username): ?User
     {
-        return ! empty($username) ? $this->getServer()->members->filter(function ($member) use ($username) {
+        return ! empty($username) ? $this->discord()->users->filter(function ($user) use ($username) {
             $username = str_replace(['<', '@', '>'], '', strtolower($username));
 
-            return ($member->user->username === $username || $member->user->id === $username) && ! $member->user->bot;
+            return ($user->username === $username || $user->id === $username) && ! $user->bot;
         })->first() : null;
     }
 
@@ -180,16 +170,6 @@ abstract class AbstractCommand
             'discord_id' => $user->id,
             'username' => $user->username,
         ]) ?? null;
-    }
-
-    /**
-     * Get the command server.
-     *
-     * @return \Discord\Parts\Guild\Guild
-     */
-    public function getServer()
-    {
-        return $this->server;
     }
 
     /**

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -47,8 +47,6 @@ abstract class Command extends AbstractCommand implements CommandContract
             return;
         }
 
-        $this->server = $message->channel->guild;
-
         if (! $this->isAdminCommand()) {
             $this->handle($message, $args);
 

--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -153,7 +153,7 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
                     }
 
                     return Choice::new($this->discord(), $key, $choice);
-                })->values()->all();
+                })->values()->take(25)->all();
             }
 
             if ($option->type === Option::SUB_COMMAND || $option->type === Option::SUB_COMMAND_GROUP) {

--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -139,7 +139,9 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
             $value = Arr::get($this->autocomplete(), $path);
 
             if ($option->focused && $value) {
-                $choices = $value($interaction, $option->value);
+                $choices = is_callable($value)
+                    ? $value($interaction, $option->value)
+                    : Arr::wrap($value);
 
                 return collect($choices)->map(function ($choice, $key) use ($choices) {
                     if ($choice instanceof Choice) {

--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -86,8 +86,6 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
      */
     public function maybeHandle($interaction)
     {
-        $this->server = $interaction->guild;
-
         if (! $this->isAdminCommand()) {
             $this->parseOptions($interaction);
 

--- a/src/Laracord.php
+++ b/src/Laracord.php
@@ -546,7 +546,11 @@ class Laracord
         }
 
         $registered->each(function ($command, $name) {
-            $this->discord()->listenCommand($name, fn ($interaction) => $this->handleSafe($name, fn () => $command['state']->maybeHandle($interaction)));
+            $this->discord()->listenCommand(
+                $name,
+                fn ($interaction) => $this->handleSafe($name, fn () => $command['state']->maybeHandle($interaction)),
+                fn ($interaction) => $this->handleSafe($name, fn () => $command['state']->maybeHandleAutocomplete($interaction))
+            );
 
             $this->registerInteractions($name, $command['state']->interactions());
         });


### PR DESCRIPTION
This PR adds a better syntax and the possibility to handle autocomplete within Slash Commands
It provides 3 ways of syntax

Using a choice class
```php
public function autocomplete(): array
    {
        return [
            'attribute' => fn ($interaction, $value) => [
                Choice::new($this->discord(), 'attribute', 'attribute'),
            ],
        ];
    }
```

Using key value pairs
```php
public function autocomplete(): array
    {
        return [
            'attribute' => fn ($interaction, $value) => [
                'attribute' => 'attribute',
            ],
        ];
    }
```

Using just an array of strings, with this option the autocomplete handler takes the liberty of using the string to create a name for the choice slugified, this last option might be too opinionated but let me know your thoughts.
```php
public function autocomplete(): array
    {
        return [
            'attribute' => fn ($interaction, $value) => [
                'attribute',
            ],
        ];
    }
```

