### PR TITLE
🩹 Fix CanAsync infinite loop

### DIFF
--- a/src/Concerns/CanAsync.php
+++ b/src/Concerns/CanAsync.php
@@ -33,6 +33,6 @@ trait CanAsync
      */
     public function async(callable $callback): Promise
     {
-        return static::async($callback);
+        return static::handleAsync($callback);
     }
 }


### PR DESCRIPTION
The previous implementation of the async method within CanAsync referenced itself, hence causing an infinite loop