### PR TITLE
Use the message user id instead of the interaction user id

### DIFF
--- a/src/Discord/Message.php
+++ b/src/Discord/Message.php
@@ -358,7 +358,7 @@ class Message
     public function editOrReply(Interaction|ChannelMessage $message, bool $ephemeral = false): ExtendedPromiseInterface
     {
         if ($message instanceof Interaction) {
-            return $message->user->id === $this->bot->discord()->id
+            return $message->message?->user_id === $this->bot->discord()->id
                 ? $this->edit($message)
                 : $this->reply($message, $ephemeral);
         }


### PR DESCRIPTION
This PR fixes an issue with the editOrReply functionality. 
If we use the interaction->user->id it will always be false compared to the discord id, this PR updates it to use the message user id instead which lets the message be edited.

