### PR TITLE
✨ Initial support for Context Menus

### DIFF
--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -3,6 +3,7 @@
 namespace Laracord\Commands;
 
 use Discord\Parts\Guild\Guild;
+use Discord\Parts\Interactions\Command\Command as DiscordCommand;
 use Discord\Parts\User\User;
 use Illuminate\Support\Str;
 use Laracord\Discord\Concerns\HasModal;
@@ -81,6 +82,13 @@ abstract class AbstractCommand
      * @var bool
      */
     protected $enabled = true;
+
+    /**
+     * The command type, determining how the command should be accessed on Discord.
+     *
+     * @var int
+     */
+    protected $type = DiscordCommand::CHAT_INPUT;
 
     /**
      * Create a new command instance.
@@ -278,5 +286,13 @@ abstract class AbstractCommand
     public function isEnabled(): bool
     {
         return $this->enabled;
+    }
+
+    /**
+     * Retrieve the command type.
+     */
+    public function getType()
+    {
+        return $this->type;
     }
 }

--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -50,7 +50,13 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
     {
         $command = CommandBuilder::new()
             ->setName($this->getName())
+            ->setType($this->getType())
             ->setDescription($this->getDescription());
+
+//        Possible issue with upstream dependency, not allowing empty descriptions
+//        if($this->getType() !== DiscordCommand::CHAT_INPUT) {
+//            $command = $command->setDescription(null);
+//        }
 
         if ($permissions = $this->getPermissions()) {
             $command = $command->setDefaultMemberPermissions($permissions);
@@ -172,6 +178,11 @@ abstract class SlashCommand extends AbstractCommand implements SlashCommandContr
      */
     protected function parseOptions(Interaction $interaction): void
     {
+        if ($interaction->type !== DiscordCommand::CHAT_INPUT) {
+            $this->parsedOptions = [];
+            return;
+        }
+
         $this->parsedOptions = json_decode($interaction->data->options->serialize(), true);
     }
 

--- a/src/Console/Commands/stubs/slash-command.stub
+++ b/src/Console/Commands/stubs/slash-command.stub
@@ -4,6 +4,7 @@ namespace {{ namespace }};
 
 use Discord\Parts\Interactions\Interaction;
 use Laracord\Commands\SlashCommand;
+use Discord\Parts\Interactions\Command\Command as DiscordCommand;
 
 class {{ class }} extends SlashCommand
 {
@@ -50,6 +51,13 @@ class {{ class }} extends SlashCommand
     protected $hidden = false;
 
     /**
+     * The command type, determining how the command should be accessed on Discord. Default is CHAT_INPUT.
+     *
+     * @var int
+     */
+    protected $type = DiscordCommand::CHAT_INPUT;
+
+    /**
      * Handle the slash command.
      *
      * @param  \Discord\Parts\Interactions\Interaction  $interaction
@@ -73,7 +81,7 @@ class {{ class }} extends SlashCommand
     public function interactions(): array
     {
         return [
-            'wave' => fn (Interaction $interaction) => $this->message('👋')->reply($interaction), 
+            'wave' => fn (Interaction $interaction) => $this->message('👋')->reply($interaction),
         ];
     }
 }


### PR DESCRIPTION
This aims to add Message and User context menu support to slash commands, I'm unsure how we'd want to structure this, for example having a separate folder to contain these types of interactions or build onto #71 and use a parent Interactions folder to cover all bases?

Current Issues:
While this system with the existing interaction handlers, the issue I have met is regarding registration, specifically within the `SlashCommand` create() function, it appears the discord-php command builder doesn't allow creation of commands without a description. I did have a look at the source code of the library and other relating issues like [this one](https://github.com/discord-php/DiscordPHP/issues/691) however I'm personally unsure if this would require a pull request to adjust the command builder itself. 

I did attempt to mitigate this with the follow code:

```php
    $command = CommandBuilder::new()
        ->setName($this->getName())
        ->setType($this->getType());
        
    if($this->getType() !== DiscordCommand::CHAT_INPUT) {
        $command = $command->setDescription($this->getDescription());
    }
```

However, this creates a typed property error as $description is accessed before initialization (This relates to the `CommandBuilder` within discord-php)

I may have missed the mark somewhere along the line of attempting to add this support, however feedback is appreciated. 