### PR TITLE
🩹 Fix token authorization

### DIFF
--- a/src/Http/Middleware/AuthorizeToken.php
+++ b/src/Http/Middleware/AuthorizeToken.php
@@ -15,7 +15,7 @@ class AuthorizeToken
      */
     public function handle(Request $request, Closure $next)
     {
-        $token = $request->bearerToken() ?? $request->query('token');
+        $token = $request->bearerToken() ?? $request->input('token');
 
         if (! $token) {
             return response()->json(['message' => 'You must specify a token.'], 401);


### PR DESCRIPTION
Currently, if we define the following HTTP route:

```php
Route::middleware('api')->group(function () {
    Route::post('/test', ExampleController::class);
});
```

we won't be able to access it if we send a POST request to:

```
http://localhost:8080/test?token=mytoken
```

because internally, Symfony [clears the query parameters](https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/HttpFoundation/Request.php#L337-L353) for non GET requests.