### PR TITLE
🩹 Fix token authorization

### DIFF
--- a/src/Http/Middleware/AuthorizeToken.php
+++ b/src/Http/Middleware/AuthorizeToken.php
@@ -15,7 +15,7 @@ class AuthorizeToken
      */
     public function handle(Request $request, Closure $next)
     {
-        $token = $request->bearerToken() ?? $request->input('token');
+        $token = $request->bearerToken() ?? $request->get('token');
 
         if (! $token) {
             return response()->json(['message' => 'You must specify a token.'], 401);


### PR DESCRIPTION
My previous PR (#112) doesn't handle the case when someone makes a request with the `Content-Type: application/json` header. The [`$request->input`](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Http/Concerns/InteractsWithInput.php#L303) method will use the [JSON data](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Http/Request.php#L423) (payload) instead of the request data (parameters).

The easiest fix is to use the [`$request->get`](https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/HttpFoundation/Request.php#L638) method from Symfony, as it can retrieve data from both the query string and request body parameters.