### PR TITLE
🩹 Fix bad method call exception in the `Server` class

### DIFF
--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use React\Http\HttpServer;
 use React\Http\Message\Response;
 use React\Socket\SocketServer;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Throwable;
 
 class Server
@@ -141,7 +142,7 @@ class Server
             return new Response(
                 $response->getStatusCode(),
                 $response->headers->allPreserveCase(),
-                $response->getContent() ?: $response->getFile()?->getContent() ?: ''
+                $response->getContent() ?: ($response instanceof BinaryFileResponse ? $response->getFile()->getContent() : false) ?: ''
             );
         });
     }


### PR DESCRIPTION
The `?->` operator can't be used if the method doesn't exist (which will be the case if the response is not a file):

```php
use Illuminate\Http\Response;

return new Response('', Response::HTTP_NO_CONTENT); // Empty response
```