### PR TITLE
Support for passing bot name and token on bot:boot command

### DIFF
--- a/src/Console/Commands/BootCommand.php
+++ b/src/Console/Commands/BootCommand.php
@@ -2,8 +2,8 @@
 
 namespace Laracord\Console\Commands;
 
-use Illuminate\Support\Str;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 class BootCommand extends Command
 {
@@ -43,6 +43,7 @@ class BootCommand extends Command
         // Check if bot token is provided
         if (empty($botToken)) {
             $this->error('Bot token is required.');
+
             return;
         }
 
@@ -52,6 +53,7 @@ class BootCommand extends Command
         // Create the bot instance using singleton with the bot name and token
         $this->app->singleton('bot', function () {
             $botClass = $this->getClass();
+
             return $botClass::make($this, config('discord.description'), config('discord.token'));
         });
 
@@ -64,7 +66,7 @@ class BootCommand extends Command
      */
     protected function getClass(): string
     {
-        $class = Str::start($this->app->getNamespace(), '\\') . 'Bot';
+        $class = Str::start($this->app->getNamespace(), '\\').'Bot';
 
         return class_exists($class) ? $class : 'Laracord';
     }

--- a/src/Console/Commands/BootCommand.php
+++ b/src/Console/Commands/BootCommand.php
@@ -3,6 +3,7 @@
 namespace Laracord\Console\Commands;
 
 use Illuminate\Support\Str;
+use Illuminate\Console\Command;
 
 class BootCommand extends Command
 {
@@ -12,7 +13,9 @@ class BootCommand extends Command
      * @var string
      */
     protected $signature = 'bot:boot
-                            {--no-migrate : Boot without running database migrations}';
+                            {--no-migrate : Boot without running database migrations}
+                            {--bot_name= : The name of the bot}
+                            {--bot_token= : The token of the bot}';
 
     /**
      * The description of the command.
@@ -28,12 +31,31 @@ class BootCommand extends Command
      */
     public function handle()
     {
+        // Run migrations unless --no-migrate is specified
         if (! $this->option('no-migrate')) {
             $this->callSilent('migrate', ['--force' => true]);
         }
 
-        $this->app->singleton('bot', fn () => $this->getClass()::make($this));
+        // Retrieve bot name and token from options or environment
+        $botName = $this->option('bot_name') ?? config('discord.description');
+        $botToken = $this->option('bot_token') ?? config('discord.token');
 
+        // Check if bot token is provided
+        if (empty($botToken)) {
+            $this->error('Bot token is required.');
+            return;
+        }
+
+        // Set the bot name and token in the environment dynamically
+        config(['discord.description' => $botName, 'discord.token' => $botToken]);
+
+        // Create the bot instance using singleton with the bot name and token
+        $this->app->singleton('bot', function () {
+            $botClass = $this->getClass();
+            return $botClass::make($this, config('discord.description'), config('discord.token'));
+        });
+
+        // Boot the bot
         $this->app->make('bot')->boot();
     }
 
@@ -42,7 +64,7 @@ class BootCommand extends Command
      */
     protected function getClass(): string
     {
-        $class = Str::start($this->app->getNamespace(), '\\').'Bot';
+        $class = Str::start($this->app->getNamespace(), '\\') . 'Bot';
 
         return class_exists($class) ? $class : 'Laracord';
     }


### PR DESCRIPTION
This allows multiple instances of the bot command from a terminal, with different configuration values.