### PR TITLE
Add a secure call to the handle method

### DIFF
--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -86,7 +86,7 @@ abstract class Service implements ServiceContract
 
         $this->bot->getLoop()->addPeriodicTimer(
             $this->getInterval(),
-            fn () => $this->handle()
+            fn () => $this->bot->handleSafe($this->getName(), fn () => $this->handle())
         );
 
         return $this;


### PR DESCRIPTION
Previously, when an exception appeared in the Service, the application crashed.

This small change fixes this issue. Now, when an exception appears, the console will display a beautiful error message, and the application will continue to work.