### PR TITLE
Fix inconsistent logic

### DIFF
--- a/src/Bot/Concerns/HasApplicationCommands.php
+++ b/src/Bot/Concerns/HasApplicationCommands.php
@@ -242,21 +242,7 @@ trait HasApplicationCommands
      */
     protected function registerApplicationCommand(ApplicationCommand $command): void
     {
-        if ($command->getGuild()) {
-            $guild = $this->discord()->guilds->get('id', $command->getGuild());
-
-            if (! $guild) {
-                $this->logger->warning("The <fg=yellow>{$command->getName()}</> command failed to register because the guild <fg=yellow>{$command->getGuild()}</> could not be found.");
-
-                return;
-            }
-
-            $guild->commands->save($command->create());
-
-            return;
-        }
-
-        $this->discord()->application->commands->save($command->create());
+        $command->create()->save();
     }
 
     /**

--- a/src/Bot/Concerns/HasApplicationCommands.php
+++ b/src/Bot/Concerns/HasApplicationCommands.php
@@ -2,6 +2,7 @@
 
 namespace Laracord\Bot\Concerns;
 
+use Discord\Discord;
 use Discord\Parts\Interactions\Command\Option;
 use Illuminate\Support\Arr;
 use Laracord\Bot\Hook;
@@ -11,6 +12,11 @@ use Laracord\Commands\ContextMenu;
 use function React\Async\await;
 use function React\Promise\all;
 
+/**
+ * Concern to manage application commands.
+ * 
+ * @method Discord discord() Get the Discord instance.
+ */
 trait HasApplicationCommands
 {
     /**
@@ -44,14 +50,14 @@ trait HasApplicationCommands
 
         $existing = [];
 
-        $existing[] = $this->discord->application->commands->freshen();
+        $existing[] = $this->discord()->application->commands->freshen();
 
-        foreach ($this->discord->guilds as $guild) {
+        foreach ($this->discord()->guilds as $guild) {
             $existing[] = $guild->commands->freshen();
         }
 
         $existing = all($existing)->then(fn ($commands) => collect($commands)
-            ->flatMap(fn ($command) => $command->toArray())
+            ->flatMap(fn ($command) => $command->jsonSerialize())
             ->map(fn ($command) => collect($command->getCreatableAttributes())
                 ->merge([
                     'id' => $command->id,
@@ -182,7 +188,7 @@ trait HasApplicationCommands
             if ($command['state'] instanceof ContextMenu) {
                 $menu = $command['state'];
 
-                $this->discord->listenCommand(
+                $this->discord()->listenCommand(
                     $name,
                     fn ($interaction) => rescue(fn () => $menu->maybeHandle($interaction))
                 );
@@ -208,7 +214,7 @@ trait HasApplicationCommands
             $subcommands = $subcommands->merge($subcommandGroups);
 
             if ($subcommands->isNotEmpty()) {
-                $subcommands->each(fn ($names) => $this->discord->listenCommand(
+                $subcommands->each(fn ($names) => $this->discord()->listenCommand(
                     $names,
                     fn ($interaction) => rescue(fn () => $command->maybeHandle($interaction)),
                     fn ($interaction) => rescue(fn () => $command->maybeHandleAutocomplete($interaction))
@@ -217,7 +223,7 @@ trait HasApplicationCommands
                 return;
             }
 
-            $this->discord->listenCommand(
+            $this->discord()->listenCommand(
                 $name,
                 fn ($interaction) => rescue(fn () => $command->maybeHandle($interaction)),
                 fn ($interaction) => rescue(fn () => $command->maybeHandleAutocomplete($interaction))
@@ -237,7 +243,7 @@ trait HasApplicationCommands
     protected function registerApplicationCommand(ApplicationCommand $command): void
     {
         if ($command->getGuild()) {
-            $guild = $this->discord->guilds->get('id', $command->getGuild());
+            $guild = $this->discord()->guilds->get('id', $command->getGuild());
 
             if (! $guild) {
                 $this->logger->warning("The <fg=yellow>{$command->getName()}</> command failed to register because the guild <fg=yellow>{$command->getGuild()}</> could not be found.");
@@ -250,7 +256,7 @@ trait HasApplicationCommands
             return;
         }
 
-        $this->discord->application->commands->save($command->create());
+        $this->discord()->application->commands->save($command->create());
     }
 
     /**
@@ -259,7 +265,7 @@ trait HasApplicationCommands
     protected function unregisterApplicationCommand(string $id, ?string $guildId = null): void
     {
         if ($guildId) {
-            $guild = $this->discord->guilds->get('id', $guildId);
+            $guild = $this->discord()->guilds->get('id', $guildId);
 
             if (! $guild) {
                 $this->logger->warning("The command with ID <fg=yellow>{$id}</> failed to unregister because the guild <fg=yellow>{$guildId}</> could not be found.");
@@ -272,6 +278,6 @@ trait HasApplicationCommands
             return;
         }
 
-        $this->discord->application->commands->delete($id);
+        $this->discord()->application->commands->delete($id);
     }
 }

--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -15,6 +15,13 @@ abstract class AbstractCommand
     use HasHandler, HasLaracord, HasModal;
 
     /**
+     * The command usage.
+     *
+     * @var string
+     */
+    protected $usage = '';
+
+    /**
      * The command name.
      *
      * @var string
@@ -123,7 +130,7 @@ abstract class AbstractCommand
     public function isAdmin(User|string $user): bool
     {
         if (! $user instanceof User) {
-            $user = $this->discord->users->get('id', $user);
+            $user = $this->discord()->users->get('id', $user);
         }
 
         if ($this->bot->getAdmins()) {
@@ -168,6 +175,7 @@ abstract class AbstractCommand
     {
         $command = $this->getSignature();
 
+        /** @todo Remove reference to usage */
         if (filled($this->usage)) {
             $command .= " `{$this->usage}`";
         }

--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -175,7 +175,6 @@ abstract class AbstractCommand
     {
         $command = $this->getSignature();
 
-        /** @todo Remove reference to usage */
         if (filled($this->usage)) {
             $command .= " `{$this->usage}`";
         }

--- a/src/Commands/ApplicationCommand.php
+++ b/src/Commands/ApplicationCommand.php
@@ -3,6 +3,8 @@
 namespace Laracord\Commands;
 
 use Closure;
+use Discord\Builders\CommandBuilder;
+use Discord\Parts\Interactions\Command\Command;
 use Discord\Parts\Interactions\Interaction;
 use Discord\Parts\Permissions\RolePermission;
 
@@ -24,6 +26,30 @@ abstract class ApplicationCommand extends AbstractCommand
      * Determine if the command is not safe for work.
      */
     protected bool $nsfw = false;
+
+     /**
+     * Create a Discord command instance.
+     */
+    public function create(): Command
+    {
+        $command = CommandBuilder::new()
+            ->setName($this->getName())
+            ->setDescription($this->getDescription())
+            ->setType($this->getType())
+            ->setDmPermission($this->canDirectMessage())
+            ->setNsfw($this->isNsfw());
+
+        if ($permissions = $this->getPermissions()) {
+            $command = $command->setDefaultMemberPermissions($permissions);
+        }
+
+        $command = collect($command->jsonSerialize())
+            ->put('guild_id', $this->getGuild())
+            ->filter()
+            ->all();
+
+        return new Command($this->discord(), $command);
+    }
 
     /**
      * Retrieve the slash command bitwise permission.

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -18,13 +18,6 @@ abstract class Command extends AbstractCommand implements CommandContract
     protected $aliases = [];
 
     /**
-     * The command usage.
-     *
-     * @var string
-     */
-    protected $usage = '';
-
-    /**
      * Maybe handle the command.
      */
     public function maybeHandle(Message $message, array $args): void

--- a/src/Commands/SlashCommand.php
+++ b/src/Commands/SlashCommand.php
@@ -52,7 +52,7 @@ abstract class SlashCommand extends ApplicationCommand implements SlashCommandCo
             }
         }
 
-        $command = collect($command->toArray())
+        $command = collect($command->jsonSerialize())
             ->put('guild_id', $this->getGuild())
             ->filter()
             ->all();


### PR DESCRIPTION
This pull request refactors how the Discord instance is accessed throughout the bot's application command logic, introduces a `create` method for building Discord command objects, and moves the `usage` property to a more appropriate location. The main themes are code consistency, improved command construction, and minor cleanup.

**Refactoring Discord Instance Access:**

* Replaces direct property access (`$this->discord`) with a method call (`$this->discord()`) throughout the `HasApplicationCommands` concern and related command classes to standardize and encapsulate how the Discord instance is retrieved. [[1]](diffhunk://#diff-2f0ca82bdcd0de93ed291aee2b869f268c878c424a7ad67574f830540cd0f0fbL47-R60) [[2]](diffhunk://#diff-2f0ca82bdcd0de93ed291aee2b869f268c878c424a7ad67574f830540cd0f0fbL185-R191) [[3]](diffhunk://#diff-2f0ca82bdcd0de93ed291aee2b869f268c878c424a7ad67574f830540cd0f0fbL211-R217) [[4]](diffhunk://#diff-2f0ca82bdcd0de93ed291aee2b869f268c878c424a7ad67574f830540cd0f0fbL220-R226) [[5]](diffhunk://#diff-2f0ca82bdcd0de93ed291aee2b869f268c878c424a7ad67574f830540cd0f0fbL240-R246) [[6]](diffhunk://#diff-2f0ca82bdcd0de93ed291aee2b869f268c878c424a7ad67574f830540cd0f0fbL253-R259) [[7]](diffhunk://#diff-2f0ca82bdcd0de93ed291aee2b869f268c878c424a7ad67574f830540cd0f0fbL262-R268) [[8]](diffhunk://#diff-2f0ca82bdcd0de93ed291aee2b869f268c878c424a7ad67574f830540cd0f0fbL275-R281) [[9]](diffhunk://#diff-f4c3dcedafc674e3c2310cb039fe2640501c14a2d8684abd642c3a308f353c17L126-R133)

**Command Construction Improvements:**

* Adds a `create` method to the `ApplicationCommand` class for building Discord command objects using `CommandBuilder`, ensuring consistent construction and serialization of commands.
* Updates command serialization to use `jsonSerialize()` instead of `toArray()` for compatibility and accuracy in both `HasApplicationCommands` and `SlashCommand`. [[1]](diffhunk://#diff-2f0ca82bdcd0de93ed291aee2b869f268c878c424a7ad67574f830540cd0f0fbL47-R60) [[2]](diffhunk://#diff-ff697d9bf587ad94f79a9ce6496f61a7c5fd6b6b3d144d2bb1169bb81a3ecee0L55-R55)

**Code Organization and Cleanup:**

* Moves the `usage` property from the `Command` class to the more general `AbstractCommand` class, ensuring all commands can define usage information. [[1]](diffhunk://#diff-f4c3dcedafc674e3c2310cb039fe2640501c14a2d8684abd642c3a308f353c17R17-R23) [[2]](diffhunk://#diff-bbed67cd77c30f97380058886057041a1958207f225267e7c280396535a6f3a6L20-L26)
* Adds a docblock to the `HasApplicationCommands` trait for clarity and documentation.

**Dependency Imports:**

* Adds missing imports for `Discord\Discord`, `CommandBuilder`, and `Command` where necessary for type safety and clarity. [[1]](diffhunk://#diff-2f0ca82bdcd0de93ed291aee2b869f268c878c424a7ad67574f830540cd0f0fbR5) [[2]](diffhunk://#diff-07498ae5f3d3d58b9bb2307dbbee93d58c8252e0d3e2d0b37ddef5fc86c98a6cR6-R7)